### PR TITLE
Improve performance of `SystemTime` by using `Duration` internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Improve performance of `SystemTime` by using `Duration` internally.
+
 ## [0.2.3] - 2023-10-23
 
 ### Changed


### PR DESCRIPTION
The original reason was that according to ECMA `Date.now()` can actually return negative numbers, but that isn't really practically possible in our use-case here.

I'm sure there are some weird JS environments out there that might support something like this, but `web-time` is targeting Web and browsers, which shouldn't be supporting that.

Cc #17.