### PR TITLE
fix: private field access

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -37,13 +37,16 @@ pub trait SystemTimeExt {
 
 impl SystemTimeExt for SystemTime {
 	fn to_std(self) -> std::time::SystemTime {
-		StdSystemTime::UNIX_EPOCH + self.0
+		StdSystemTime::UNIX_EPOCH
+			+ self
+				.duration_since(Self::UNIX_EPOCH)
+				.expect("found `SystemTime` earlier than unix epoch")
 	}
 
 	fn from_std(time: std::time::SystemTime) -> SystemTime {
 		Self::UNIX_EPOCH
 			+ time
 				.duration_since(StdSystemTime::UNIX_EPOCH)
-				.expect("found `SystemTime` earlier then unix epoch")
+				.expect("found `SystemTime` earlier than unix epoch")
 	}
 }


### PR DESCRIPTION
## Problem

Compilation fails with `RUSTFLAGS="--cfg docsrs"`

```rust
error[E0616]: field `0` of struct `std::time::SystemTime` is private
  --> src/web.rs:40:36
   |
40 |         StdSystemTime::UNIX_EPOCH + self.0
   |                                          ^ private field

For more information about this error, try `rustc --explain E0616`.
```

## Fix

Replace `self.0` with `self.duration_since(UNIX_EPOCH)`