### PR TITLE
chore: silence unused qualifications warnings

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -19,6 +19,7 @@ pub trait SystemTimeExt {
 	/// incompatible APIs of other dependencies, care should be taken that the
 	/// dependency in question doesn't call [`std::time::SystemTime::now()`]
 	/// internally, which would panic.
+	#[allow(unused_qualifications)]
 	fn to_std(self) -> std::time::SystemTime;
 
 	/// Convert [`std::time::SystemTime`] to
@@ -32,14 +33,17 @@ pub trait SystemTimeExt {
 	/// incompatible APIs of other dependencies, care should be taken that the
 	/// dependency in question doesn't call [`std::time::SystemTime::now()`]
 	/// internally, which would panic.
+	#[allow(unused_qualifications)]
 	fn from_std(time: std::time::SystemTime) -> SystemTime;
 }
 
 impl SystemTimeExt for SystemTime {
+	#[allow(unused_qualifications)]
 	fn to_std(self) -> std::time::SystemTime {
 		StdSystemTime::UNIX_EPOCH + self.0
 	}
 
+	#[allow(unused_qualifications)]
 	fn from_std(time: std::time::SystemTime) -> SystemTime {
 		Self::UNIX_EPOCH
 			+ time


### PR DESCRIPTION
Silencing the following loud warnings.

```rust
warning: unnecessary qualification
  --> src/web.rs:22:21
   |
22 |     fn to_std(self) -> std::time::SystemTime;
   |                        ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: requested on the command line with `-W unused-qualifications`
help: remove the unnecessary path segments
   |
22 -     fn to_std(self) -> std::time::SystemTime;
22 +     fn to_std(self) -> SystemTime;
   |

warning: unnecessary qualification
  --> src/web.rs:35:20
   |
35 |     fn from_std(time: std::time::SystemTime) -> SystemTime;
   |                       ^^^^^^^^^^^^^^^^^^^^^
   |
help: remove the unnecessary path segments
   |
35 -     fn from_std(time: std::time::SystemTime) -> SystemTime;
35 +     fn from_std(time: SystemTime) -> SystemTime;
   |

warning: unnecessary qualification
  --> src/web.rs:39:21
   |
39 |     fn to_std(self) -> std::time::SystemTime {
   |                        ^^^^^^^^^^^^^^^^^^^^^
   |
help: remove the unnecessary path segments
   |
39 -     fn to_std(self) -> std::time::SystemTime {
39 +     fn to_std(self) -> SystemTime {
   |

warning: unnecessary qualification
  --> src/web.rs:46:20
   |
46 |     fn from_std(time: std::time::SystemTime) -> SystemTime {
   |                       ^^^^^^^^^^^^^^^^^^^^^
   |
help: remove the unnecessary path segments
   |
46 -     fn from_std(time: std::time::SystemTime) -> SystemTime {
46 +     fn from_std(time: SystemTime) -> SystemTime {
   |
```

Feel free to close if you prefer to address these warnings differently.