### PR TITLE
Don't mention instant as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ not with `RUSTFLAGS`.
 As this library heavily relies on [`wasm-bindgen`] the MSRV depends on it. At the point of time this
 was written the MSRV is 1.60.
 
-## Alternatives
-
-[instant](https://crates.io/crates/instant)
-[![Crates.io](https://img.shields.io/crates/v/instant.svg)](https://crates.io/crates/instant) is a
-popular alternative! However the API it implements doesn't match [`std::time`] exactly.
-
 ## Changelog
 
 See the [CHANGELOG] file for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,6 @@
 //! As this library heavily relies on [`wasm-bindgen`] the MSRV depends on it.
 //! At the point of time this was written the MSRV is 1.60.
 //!
-//! # Alternatives
-//!
-//! [instant](https://crates.io/crates/instant) [![Crates.io](https://img.shields.io/crates/v/instant.svg)](https://crates.io/crates/instant) is a popular alternative! However the API it implements doesn't match [`std::time`] exactly.
-//!
 //! # Contributing
 //!
 //! See the [CONTRIBUTING] file for details.


### PR DESCRIPTION
Don't mention the unmaintained `instant` crate as an alternative.