### PR TITLE
Add `no_std` support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.wasm32-unknown-unknown]
+[target.'cfg(target_family = "wasm")']
 runner = "wasm-bindgen-test-runner"

--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,7 +1,8 @@
-23
+25
 1G
 1M
 1ns
+allocator
 APIs
 Atomics
 de
@@ -12,6 +13,7 @@ io
 JS
 MDN
 MSRV
+representable
 Serde
 Serde's
 timestamps

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Build
 
 on:
   push:
@@ -13,9 +13,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  clippy:
+  build:
     name:
-      Clippy ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
+      Build ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
       matrix.features.description }}
 
     runs-on: ubuntu-latest
@@ -28,70 +28,7 @@ jobs:
           - { target: wasm32-unknown-unknown, description: Web }
           - { target: wasm32v1-none, description: Wasm v1 }
         rust:
-          - { version: stable, atomics: false }
-          - { version: nightly, atomics: false }
-          - {
-              version: nightly,
-              description: with Atomics,
-              atomics: true,
-              component: ",rust-src",
-              flags: "-Ctarget-feature=+atomics,+bulk-memory",
-              build-std: true,
-            }
-        features:
-          - { features: "", no_std: false }
-          - { features: --features serde, no_std: false, description: (`serde`) }
-          - { features: --no-default-features, no_std: true, description: (`no_std`) }
-          - {
-              features: --no-default-features --features serde,
-              no_std: true,
-              description: "(`no_std`, `serde`)",
-            }
-        exclude:
-          - target: { target: x86_64-unknown-linux-gnu, description: Native }
-            rust: { version: nightly }
-          - target: { target: wasm32-unknown-unknown, description: Web }
-            rust: { version: nightly, atomics: false }
-          - target: { target: wasm32v1-none, description: Wasm v1 }
-            rust: { version: stable }
-          - target: { target: wasm32v1-none, description: Wasm v1 }
-            features: { no_std: false }
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Rust
-        run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile minimal --component clippy${{ matrix.rust.component }} --allow-downgrade --target ${{ matrix.target.target }}
-          rustup default ${{ matrix.rust.version }}
-      - name: Set `build-std` components
-        if: matrix.rust.build-std == true && matrix.features.no_std == false
-        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=panic_abort,std" >> $GITHUB_ENV
-      - name: Set `build-std` `no_std` components
-        if: matrix.rust.build-std == true && matrix.features.no_std == true
-        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
-      - name: Run Clippy
-        env:
-          RUSTFLAGS: ${{ matrix.rust.flags }}
-        run:
-          cargo clippy --workspace --all-targets ${{ matrix.features.features }} --target ${{
-          matrix.target.target }} $BUILD_STD_COMPONENTS -- -D warnings
-
-  rustdoc:
-    name:
-      Rustdoc ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
-      matrix.features.description }} ${{ matrix.docsrs.description }}
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - { target: x86_64-unknown-linux-gnu, description: Native }
-          - { target: wasm32-unknown-unknown, description: Web }
-          - { target: wasm32v1-none, description: Wasm v1 }
-        rust:
+          - { version: "1.60", description: MSRV, atomics: false }
           - { version: stable, atomics: false }
           - { version: nightly, atomics: false }
           - {
@@ -111,20 +48,13 @@ jobs:
               no_std: true,
               description: "(`no_std`, `serde`)",
             }
-        docsrs:
-          - { flags: "", nightly: false }
-          - { description: (docs.rs), flags: --cfg=docsrs, nightly: true }
         exclude:
-          - docsrs: { flags: --cfg=docsrs, nightly: true }
-            rust: { version: stable }
           - target: { target: x86_64-unknown-linux-gnu, description: Native }
-            rust: { atomics: true }
-          - target: { target: x86_64-unknown-linux-gnu, description: Native }
-            docsrs: { flags: "", nightly: false }
             rust: { version: nightly }
           - target: { target: wasm32-unknown-unknown, description: Web }
-            docsrs: { flags: "", nightly: false }
             rust: { version: nightly, atomics: false }
+          - target: { target: wasm32v1-none, description: Wasm v1 }
+            rust: { version: "1.60" }
           - target: { target: wasm32v1-none, description: Wasm v1 }
             rust: { version: stable }
           - target: { target: wasm32v1-none, description: Wasm v1 }
@@ -143,10 +73,76 @@ jobs:
       - name: Set `build-std` `no_std` components
         if: matrix.rust.build-std == true && matrix.features.no_std == true
         run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
-      - name: Run Rustdoc
+      - name: Fix MSRV dependencies
+        if: matrix.rust.version == '1.60'
+        run: |
+          cargo update -p bumpalo --precise 3.14.0
+          cargo update -p serde --precise 1.0.210
+          cargo update -p syn --precise 2.0.67
+      - name: Build
         env:
           RUSTFLAGS: ${{ matrix.rust.flags }}
-          RUSTDOCFLAGS: -D warnings ${{ matrix.rust.flags }} ${{ matrix.docsrs.flags }}
         run:
-          cargo doc --workspace --no-deps --document-private-items --lib --examples ${{
-          matrix.features.features }} --target ${{ matrix.target.target }} $BUILD_STD_COMPONENTS
+          cargo build ${{ matrix.features.features }} --target ${{ matrix.target.target }}
+          $BUILD_STD_COMPONENTS
+
+  minimal-versions:
+    name:
+      Minimal Versions ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
+      matrix.features.description }}
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: minimal-versions
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { target: x86_64-unknown-linux-gnu, description: Native }
+          - { target: wasm32-unknown-unknown, description: Web }
+          - { target: wasm32v1-none, description: Wasm v1 }
+        rust:
+          - { version: "1.60", description: MSRV }
+          - { version: stable }
+          - { version: nightly }
+        features:
+          - { features: "", no_std: false }
+          - { features: --features serde, no_std: false, description: (`serde`) }
+          - { features: --no-default-features, no_std: true, description: (`no_std`) }
+          - {
+              features: --no-default-features --features serde,
+              no_std: true,
+              description: "(`no_std`, `serde`)",
+            }
+        exclude:
+          - target: { target: x86_64-unknown-linux-gnu, description: Native }
+            rust: { version: nightly }
+          - target: { target: wasm32-unknown-unknown, description: Web }
+            rust: { version: nightly }
+          - target: { target: wasm32v1-none, description: Wasm v1 }
+            rust: { version: "1.60" }
+          - target: { target: wasm32v1-none, description: Wasm v1 }
+            rust: { version: stable }
+          - target: { target: wasm32v1-none, description: Wasm v1 }
+            features: { no_std: false }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup toolchain install ${{ matrix.rust.version }} --profile minimal --target ${{ matrix.target.target }}
+          rustup default ${{ matrix.rust.version }}
+      - name: Downgrade to minimal versions
+        run: |
+          rustup toolchain install nightly --profile minimal
+          cargo +nightly update -Z minimal-versions
+      - name: Fix Rust nightly incompatible dependencies
+        if: matrix.rust.version == 'nightly'
+        run: |
+          cargo update -p proc-macro2 --precise 1.0.60
+      - name: Build
+        run: cargo build ${{ matrix.features.features }} --target ${{ matrix.target.target }}

--- a/.github/workflows/coverage-documentation.yaml
+++ b/.github/workflows/coverage-documentation.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   coverage:
-    name: Test Coverage ${{ matrix.mt.description }}
+    name: Test Coverage ${{ matrix.mt.description }} ${{ matrix.features.description }}
 
     runs-on: ubuntu-latest
 
@@ -24,15 +24,24 @@ jobs:
     strategy:
       matrix:
         mt:
-          - { id: 0 }
+          - { id: "st" }
           - {
-              id: 1,
+              id: "mt",
               description: with Atomics,
               component: --component rust-src,
               cflags: -matomics -mbulk-memory,
               flags: "-Ctarget-feature=+atomics,+bulk-memory",
-              args: "-Zbuild-std=panic_abort,std",
+              build-std: true,
             }
+        features:
+          - { id: "", features: "", no_std: false }
+          - { id: -no_std, features: --no-default-features, no_std: true, description: (`no_std`) }
+
+    env:
+      CFLAGS_wasm32_unknown_unknown: ${{ matrix.mt.cflags }}
+      RUSTFLAGS:
+        -Cinstrument-coverage -Zcoverage-options=condition -Zno-profiler-runtime --emit=llvm-ir
+        --cfg=wasm_bindgen_unstable_test_coverage ${{ matrix.mt.flags }}
 
     steps:
       - name: Checkout
@@ -50,31 +59,25 @@ jobs:
         run: |
           rustup toolchain install nightly --profile minimal --target wasm32-unknown-unknown ${{ matrix.mt.component }}
           rustup default nightly
+      - name: Set `build-std` components
+        if: matrix.mt.build-std == true && matrix.features.no_std == false
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=panic_abort,std" >> $GITHUB_ENV
+      - name: Set `build-std` `no_std` components
+        if: matrix.mt.build-std == true && matrix.features.no_std == true
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
       - name: Test
         env:
           CHROMEDRIVER: chromedriver
-          CFLAGS_wasm32_unknown_unknown: ${{ matrix.mt.cflags }}
-          CARGO_HOST_RUSTFLAGS: --cfg=wasm_bindgen_unstable_test_coverage
-          RUSTFLAGS:
-            -Cinstrument-coverage -Zcoverage-options=condition -Zno-profiler-runtime --emit=llvm-ir
-            --cfg=wasm_bindgen_unstable_test_coverage ${{ matrix.mt.flags }}
-          WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT: coverage-output
         run: |
           mkdir coverage-output
-          cargo test --all-features --target wasm32-unknown-unknown -Ztarget-applies-to-host -Zhost-config ${{ matrix.mt.args }} --tests
+          WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT=$(realpath coverage-output) cargo test --workspace --features serde --target wasm32-unknown-unknown $BUILD_STD_COMPONENTS ${{ matrix.features.features }} --tests
       - name: Prepare Object Files
-        env:
-          CFLAGS_wasm32_unknown_unknown: ${{ matrix.mt.cflags }}
-          CARGO_HOST_RUSTFLAGS: --cfg=wasm_bindgen_unstable_test_coverage
-          RUSTFLAGS:
-            -Cinstrument-coverage -Zcoverage-options=condition -Zno-profiler-runtime --emit=llvm-ir
-            --cfg=wasm_bindgen_unstable_test_coverage ${{ matrix.mt.flags }}
         run: |
           mkdir coverage-input
           crate_name=web_time
           IFS=$'\n'
           for file in $(
-            cargo test --all-features --target wasm32-unknown-unknown -Ztarget-applies-to-host -Zhost-config ${{ matrix.mt.args }} --tests --no-run --message-format=json | \
+            cargo test --workspace --features serde --target wasm32-unknown-unknown $BUILD_STD_COMPONENTS ${{ matrix.features.features }} --tests --no-run --message-format=json | \
             jq -r "select(.reason == \"compiler-artifact\") | (select(.target.kind == [\"test\"]) // select(.target.name == \"$crate_name\")) | .filenames[0]"
           )
           do
@@ -90,7 +93,7 @@ jobs:
       - name: Upload Test Coverage Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-coverage-${{ matrix.mt.id }}
+          name: test-coverage-${{ matrix.mt.id }}${{ matrix.features.id }}
           path: coverage-output
           retention-days: 1
           if-no-files-found: error
@@ -105,11 +108,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install LLVM v19
+      - name: Install Rust nightly
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main"  
-          sudo apt-get install llvm-19
+          rustup toolchain install nightly --profile minimal --component llvm-tools
+          rustup default nightly
+      - name: Install `cargo-binutils`
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binutils
       - name: Download Test Coverage
         uses: actions/download-artifact@v4
         with:
@@ -117,8 +123,7 @@ jobs:
           path: coverage-input
       - name: Merge Profile Data
         run:
-          llvm-profdata-19 merge -sparse coverage-input/*/*.profraw -o
-          coverage-input/coverage.profdata
+          rust-profdata merge -sparse coverage-input/*/*.profraw -o coverage-input/coverage.profdata
       - name: Export Code Coverage Report
         run: |
           mkdir coverage-output
@@ -127,16 +132,15 @@ jobs:
           do
               objects+=(-object $file)
           done
-          llvm-cov-19 show -show-instantiations=false -output-dir coverage-output -format=html -instr-profile=coverage-input/coverage.profdata ${objects[@]} -sources src
-          llvm-cov-19 export -format=text -summary-only -instr-profile=coverage-input/coverage.profdata ${objects[@]} -sources src | \
+          rust-cov show -show-instantiations=false -output-dir coverage-output -format=html -instr-profile=coverage-input/coverage.profdata ${objects[@]} -sources src
+          rust-cov export -format=text -summary-only -instr-profile=coverage-input/coverage.profdata ${objects[@]} -sources src | \
           printf '{ "coverage": "%.2f%%" }' $(jq '.data[0].totals.functions.percent') > coverage-output/coverage.json
-          sed 's/<!doctype html>//' coverage-output/index.html | perl -p0e 's/<a[^>]*>((?!here).*?)<\/a>/$1/g' >> $GITHUB_STEP_SUMMARY
+          sed 's/<!doctype html>//' coverage-output/index.html | sed "s/<script src='control.js'><\/script>//" | perl -p0e 's/<a[^>]*>((?!here).*?)<\/a>/$1/g' >> $GITHUB_STEP_SUMMARY
       - name: Upload Test Coverage Artifact
         uses: actions/upload-artifact@v4
         with:
           name: test-coverage
           path: coverage-output
-          retention-days: 1
           if-no-files-found: error
 
   document:
@@ -158,7 +162,7 @@ jobs:
           RUSTDOCFLAGS: --crate-version main --cfg=docsrs
         run:
           cargo doc --no-deps -Z rustdoc-map -Z rustdoc-scrape-examples --target
-          wasm32-unknown-unknown --all-features
+          wasm32-unknown-unknown --features serde
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Fix permissions

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,5 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
       - name: Test Publish
         run: cargo publish --dry-run

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,146 +13,174 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-test:
+  test:
     name:
-      ${{ matrix.rust.pre_description }} ${{ matrix.driver.description }} ${{
-      matrix.rust.post_description }} ${{ matrix.features.description }}
+      Test ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
+      matrix.features.description }}
 
-    runs-on: ${{ matrix.driver.os }}
+    runs-on: ${{ matrix.target.os }}
 
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        driver:
+        target:
           - {
               os: ubuntu-latest,
+              target: wasm32-unknown-unknown,
               description: Chrome,
-              default: true,
               name: CHROMEDRIVER,
               value: chromedriver,
             }
-          - { os: ubuntu-latest, description: Firefox, name: GECKODRIVER, value: geckodriver }
-          - { os: macos-latest, description: Safari, name: SAFARIDRIVER, value: safaridriver }
+          - {
+              os: ubuntu-latest,
+              target: wasm32-unknown-unknown,
+              description: Firefox,
+              name: GECKODRIVER,
+              value: geckodriver,
+            }
+          - {
+              os: macos-latest,
+              target: wasm32-unknown-unknown,
+              description: Safari,
+              name: SAFARIDRIVER,
+              value: safaridriver,
+            }
         rust:
-          - { version: stable, pre_description: Build & Test, msrv: false }
+          - { version: stable }
           - {
               version: nightly,
-              pre_description: Build & Test,
-              post_description: with Atomics,
-              msrv: false,
+              description: with Atomics,
               component: --component rust-src,
               flags: "-Ctarget-feature=+atomics,+bulk-memory",
-              args: "-Zbuild-std=panic_abort,std",
+              build-std: true,
             }
-        target:
-          - { target: wasm32-unknown-unknown, native: false, docargs: -Zdoctest-xcompile }
         features:
-          - { features: "" }
-          - { features: --all-features, description: (all features) }
+          - { features: "", no_std: false }
+          - { features: --no-default-features, no_std: true, description: "(`no_std`)" }
         include:
-          - driver: { os: ubuntu-latest, description: Web, default: true }
-            rust: { version: "1.60", pre_description: Build, post_description: MSRV, msrv: true }
-            target: { target: wasm32-unknown-unknown, native: false }
-            features: { features: "" }
-          - driver: { os: ubuntu-latest, description: Native }
-            rust: { version: "1.60", pre_description: Build, post_description: MSRV, msrv: true }
-            target: { target: x86_64-unknown-linux-gnu, native: true }
-            features: { features: "" }
-          - driver: { os: ubuntu-latest, description: Native }
-            rust: { version: stable, pre_description: Build & Test, msrv: false }
-            target: { target: x86_64-unknown-linux-gnu, native: true }
-            features: { features: "" }
+          - target:
+              {
+                os: ubuntu-latest,
+                target: x86_64-unknown-linux-gnu,
+                description: Native,
+                native: true,
+              }
+            rust: { version: stable }
+            features: { features: "", no_std: false }
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install `wasm-bindgen-cli`
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli
-          git: https://github.com/daxpedda/wasm-bindgen
-          rev: 6a5e62b1d89c9e927747700b5908b257761c9280
       - name: Install Rust
         run: |
           rustup toolchain install ${{ matrix.rust.version }} --profile minimal ${{ matrix.rust.component }} --target ${{ matrix.target.target }}
           rustup default ${{ matrix.rust.version }}
-      - name: Fix MSRV dependencies
-        if: matrix.rust.msrv == true
-        run: |
-          cargo update -p bumpalo --precise 3.14.0
-          cargo update -p serde --precise 1.0.210
-          cargo update -p syn --precise 2.0.67
-      - name: Build
-        if: matrix.driver.default == true || matrix.target.native == true
-        env:
-          RUSTFLAGS: ${{ matrix.rust.flags }}
-        run:
-          cargo build ${{ matrix.features.features }} --target ${{ matrix.target.target }} ${{
-          matrix.rust.args }}
-      - name: Documentation
-        if: matrix.driver.default == true || matrix.target.native == true
-        env:
-          RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-          RUSTFLAGS: ${{ matrix.rust.flags }}
-        run:
-          cargo doc --no-deps ${{ matrix.features.features }} --target ${{ matrix.target.target }}
-          ${{ matrix.rust.args }}
+      - name: Set `build-std` components
+        if: matrix.rust.build-std == true && matrix.features.no_std == false
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=panic_abort,std" >> $GITHUB_ENV
+      - name: Set `build-std` `no_std` components
+        if: matrix.rust.build-std == true && matrix.features.no_std == true
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
       - name: Set Driver
-        if: matrix.rust.msrv == false && matrix.target.native == false
-        run: echo "${{ matrix.driver.name }}=${{ matrix.driver.value }}" >> $GITHUB_ENV
+        if: matrix.target.native == false
+        run: echo "${{ matrix.target.name }}=${{ matrix.target.value }}" >> $GITHUB_ENV
       - name: Test
-        if: matrix.rust.msrv == false
+        env:
+          RUSTFLAGS: ${{ matrix.rust.flags }}
         run:
-          cargo test ${{ matrix.features.features }} --all-targets --no-fail-fast --target ${{
-          matrix.target.target }} ${{ matrix.rust.args }}
-      - name: Switch to nightly Rust for Wasm documentation tests
-        if:
-          matrix.rust.msrv == false && matrix.target.native == false && matrix.rust.version !=
-          'nightly'
-        run: |
-          rustup toolchain install nightly --profile minimal --target ${{ matrix.target.target }}
-          rustup default nightly
-      - name: Documentation Test
-        if: matrix.rust.msrv == false
-        run:
-          cargo test ${{ matrix.features.features }} --doc --no-fail-fast --target ${{
-          matrix.target.target }} ${{ matrix.rust.args }} ${{ matrix.target.docargs }}
+          cargo test --features serde ${{ matrix.features.features }} --target ${{
+          matrix.target.target }} $BUILD_STD_COMPONENTS --workspace --all-targets
 
-  minimal-versions:
+  doctest:
     name:
-      Minimal Versions ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
+      Doctest ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
       matrix.features.description }}
 
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: minimal-versions
+    runs-on: ${{ matrix.target.os }}
+
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        rust:
-          - { version: "1.60", description: MSRV }
-          - { version: stable }
         target:
-          - { target: x86_64-unknown-linux-gnu, description: Native }
-          - { target: wasm32-unknown-unknown, description: Web }
+          - {
+              os: ubuntu-latest,
+              target: wasm32-unknown-unknown,
+              description: Chrome,
+              name: CHROMEDRIVER,
+              value: chromedriver,
+            }
+          - {
+              os: ubuntu-latest,
+              target: wasm32-unknown-unknown,
+              description: Firefox,
+              name: GECKODRIVER,
+              value: geckodriver,
+            }
+          - {
+              os: macos-latest,
+              target: wasm32-unknown-unknown,
+              description: Safari,
+              name: SAFARIDRIVER,
+              value: safaridriver,
+            }
+        rust:
+          - { version: nightly }
+          - {
+              version: nightly,
+              description: with Atomics,
+              component: --component rust-src,
+              flags: "-Ctarget-feature=+atomics,+bulk-memory",
+              build-std: true,
+            }
         features:
-          - { features: "" }
-          - { features: --all-features, description: (all features) }
+          - { features: "", no_std: false }
+          - { features: --no-default-features, no_std: true, description: "(`no_std`)" }
+        include:
+          - target:
+              {
+                os: ubuntu-latest,
+                target: x86_64-unknown-linux-gnu,
+                description: Native,
+                native: true,
+              }
+            rust: { version: stable }
+            features: { features: "", no_std: false }
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install `wasm-bindgen-cli`
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli
       - name: Install Rust
         run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile minimal --target ${{ matrix.target.target }}
+          rustup toolchain install ${{ matrix.rust.version }} --profile minimal ${{ matrix.rust.component }} --target ${{ matrix.target.target }}
           rustup default ${{ matrix.rust.version }}
-      - name: Install Rust nightly
-        run: rustup toolchain install nightly --profile minimal
-      - name: Build
+      - name: Set `build-std` components
+        if: matrix.rust.build-std == true && matrix.features.no_std == false
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=panic_abort,std" >> $GITHUB_ENV
+      - name: Set `build-std` `no_std` components
+        if: matrix.rust.build-std == true && matrix.features.no_std == true
+        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
+      - name: Set Driver and enable cross-compilation
+        if: matrix.target.native == false
         run: |
-          cargo +nightly update -Z minimal-versions
-          cargo build ${{ matrix.features.features }} --target ${{ matrix.target.target }}
+          echo "${{ matrix.target.name }}=${{ matrix.target.value }}" >> $GITHUB_ENV
+          echo "DOCTEST_XCOMPILE_ARG=-Zdoctest-xcompile" >> $GITHUB_ENV
+      - name: Doctest
+        env:
+          RUSTFLAGS: ${{ matrix.rust.flags }}
+          RUSTDOCFLAGS: ${{ matrix.rust.flags }}
+        run:
+          cargo test --features serde ${{ matrix.features.features }} --target ${{
+          matrix.target.target }} $BUILD_STD_COMPONENTS --workspace --doc ${{ matrix.target.args }}
+          $DOCTEST_XCOMPILE_ARG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add [`no_std`] support through a `std` crate feature.
+- Add support for the [`wasm32v1-none`] target.
+
+[`no_std`]: https://doc.rust-lang.org/1.82.0/reference/names/preludes.html#the-no_std-attribute
+[`wasm32v1-none`]: https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32v1-none.html
+
 ## [1.1.0] - 2024-03-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
+[workspace]
+members = ["tests-native", "tests-web"]
+resolver = "2"
+
 [package]
 autobenches = false
+autotests = false
 categories = ["api-bindings", "date-and-time", "wasm"]
 description = "Drop-in replacement for std::time for Wasm in browsers"
 edition = "2021"
@@ -12,71 +17,60 @@ rust-version = "1.60"
 version = "1.1.0"
 
 [features]
+default = ["std"]
 serde = ["dep:serde"]
+std = [
+	"wasm-bindgen/std",
+	"js-sys/std",
+	"once_cell/std",
+	"serde?/std",
+	"wasm-bindgen-test/std",
+	"getrandom/std",
+	"rand/std",
+	"tests-native/std",
+	"tests-web/std",
+]
 
-[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-js-sys = "0.3.20"
-serde = { version = "1", optional = true }
-wasm-bindgen = { version = "0.2.70", default-features = false }
-
-[profile.test]
-opt-level = 1
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+js-sys = { version = "0.3.73", default-features = false }
+once_cell = { version = "1.12.0", default-features = false }
+serde = { version = "1.0.0", optional = true, default-features = false }
+wasm-bindgen = { version = "0.2.96", default-features = false }
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_test = "1"
-static_assertions = "1"
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = { version = "0.3", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-pollster = { version = "0.4", features = ["macro"] }
+tests-native = { path = "tests-native", default-features = false, features = ["run"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8"
-wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = [
-	"CssStyleDeclaration",
-	"Document",
-	"Element",
-	"HtmlTableElement",
-	"HtmlTableRowElement",
-	"Performance",
-	"Window",
-] }
-
-[target.'cfg(all(target_family = "wasm", target_feature = "atomics"))'.dev-dependencies]
-futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
-futures-util = { version = "0.3", default-features = false }
-web-sys = { version = "0.3", features = ["OfflineAudioContext", "WorkerGlobalScope"] }
-web-thread = { git = "https://github.com/daxpedda/wasm-worker", rev = "93236ab92354cbe0a0c07e71b9888be8b3e45999", features = [
-	"audio-worklet",
-] }
+rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
+tests-web = { path = "tests-web", default-features = false, features = ["run"] }
 
 [patch.crates-io]
-wasm-bindgen-test = { git = "https://github.com/daxpedda/wasm-bindgen", branch = "web-time" }
-wasm-bindgen-test-macro = { git = "https://github.com/daxpedda/wasm-bindgen", branch = "web-time" }
+getrandom = { git = "https://github.com/daxpedda/getrandom", branch = "web-time" }
+serde_test = { git = "https://github.com/daxpedda/test", branch = "no_std" }
+
+[profile.test]
+opt-level = 1
 
 [profile.bench]
 codegen-units = 1
 lto = true
 
-[[example]]
-name = "benchmark"
-path = "benches/benchmark.rs"
-
-[[test]]
-name = "serde"
-path = "tests/serde.rs"
-required-features = ["serde"]
+[lib]
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32v1-none"]
 
-[lints.rust]
+[lints]
+workspace = true
+
+[workspace.lints.rust]
 # Rust groups.
 future_incompatible = { level = "warn", priority = -1 }
 rust_2018_compatibility = { level = "warn", priority = -1 }
@@ -106,7 +100,7 @@ unused_import_braces = "warn"
 unused_lifetimes = "warn"
 unused_qualifications = "warn"
 
-[lints.clippy]
+[workspace.lints.clippy]
 # Clippy groups.
 cargo = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
@@ -188,5 +182,5 @@ option_if_let_else = "allow"
 redundant_pub_crate = "allow"
 tabs_in_doc_comments = "allow"
 
-[lints.rustdoc]
+[workspace.lints.rustdoc]
 all = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -15,20 +15,17 @@ Currently [`Instant::now()`] and [`SystemTime::now()`] will simply panic when us
 [`Date.now()`] for [`SystemTime`] to offer a drop-in replacement that works in browsers.
 
 At the same time the library will simply re-export [`std::time`] when not using the
-`wasm32-unknown-unknown` target and will not pull in any dependencies.
+`wasm32-unknown-unknown` or `wasm32v1-none` target and will not pull in any dependencies.
 
 Additionally, if compiled with `target-feature = "atomics"` it will synchronize the timestamps to
 account for different context's, like web workers. See [`Performance.timeOrigin`] for more
 information.
 
-Using `-Ctarget-feature=+nontrapping-fptoint` will improve the performance of [`Instant::now()`] and
-[`SystemTime::now()`], but the vast majority of the time is still spent going through JS.
-
 ## Target
 
 This library specifically targets browsers, that support [`Performance.now()`], with the
-`wasm32-unknown-unknown` target. Emscripten is not supported. WASI doesn't require support as it has
-it's own native API to deal with [`std::time`].
+`wasm32-unknown-unknown` or `wasm32v1-none` target. Emscripten is not supported. WASI doesn't
+require support as it has it's own native API to deal with [`std::time`].
 
 Furthermore it depends on [`wasm-bindgen`], which is required. This library will continue to depend
 on it until a viable alternative presents itself, in which case multiple ecosystems could be
@@ -63,7 +60,18 @@ let now = Instant::now();
 let time = SystemTime::now();
 ```
 
+Using `-Ctarget-feature=+nontrapping-fptoint` will improve the performance of [`Instant::now()`] and
+[`SystemTime::now()`], but the vast majority of the time is still spent going through JS.
+
 ## Features
+
+### `std` (enabled by default)
+
+Enables the corresponding crate feature in all dependencies and allows for some optimized
+instruction output.
+
+Without this crate feature compilation the standard library is not included. Has no effect on
+targets other then `wasm32-unknown-unknown` or `wasm32v1-none`.
 
 ### `serde`
 
@@ -126,7 +134,7 @@ additional terms or conditions.
 [`Instant::now()`]: https://doc.rust-lang.org/std/time/struct.Instant.html#method.now
 [`SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html
 [`SystemTime::now()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now
-[`std::time`]: https://doc.rust-lang.org/stable/std/time/
+[`std::time`]: https://doc.rust-lang.org/std/time/
 [`performance.now()`]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
 [`Performance.timeOrigin`]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
 [`Performance` object]: https://developer.mozilla.org/en-US/docs/Web/API/performance_property

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,170 +1,80 @@
 //! Benchmark to compare different conversion methods.
 
-#[cfg(not(target_family = "wasm"))]
-fn main() {
-	panic!("made to run under `wasm32-unknown-unknown`")
-}
-
-#[cfg(target_family = "wasm")]
-#[allow(
-	clippy::too_many_lines,
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+#![expect(
 	clippy::as_conversions,
 	clippy::cast_possible_truncation,
+	clippy::cast_precision_loss,
 	clippy::cast_sign_loss,
-	clippy::min_ident_chars,
-	clippy::unwrap_used
+	clippy::unwrap_used,
+	reason = "lots of math going on here"
 )]
-#[allow(unknown_lints, clippy::incompatible_msrv)]
-fn main() {
-	use std::time::Duration;
-	use std::{array, hint};
 
-	use rand::distributions::Uniform;
-	use rand::Rng;
-	use wasm_bindgen::closure::Closure;
-	use wasm_bindgen::JsCast;
-	use web_sys::{HtmlTableElement, HtmlTableRowElement, Performance};
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
-	#[allow(clippy::missing_docs_in_private_items)]
-	fn custom_conversion(time_stamp: f64) -> Duration {
-		// CHANGED: 1G to 1M.
-		const NANOS_PER_MILLI: u32 = 1_000_000;
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+use core::time::Duration;
+use core::{array, hint};
 
-		// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#1477-1484>.
-		const MANT_BITS: i16 = 52;
-		const EXP_BITS: i16 = 11;
-		const OFFSET: i16 = 44;
+#[cfg(not(feature = "std"))]
+use const_soft_float::soft_f64::SoftF64;
+use rand::distributions::Uniform;
+use rand::rngs::{OsRng, StdRng};
+use rand::{Rng, SeedableRng};
+use tests_web as _;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlTableElement, HtmlTableRowElement};
 
-		// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#1262-1340>.
-		const MIN_EXP: i16 = 1 - (1_i16 << EXP_BITS) / 2;
-		const MANT_MASK: u64 = (1 << MANT_BITS) - 1;
-		const EXP_MASK: u64 = (1 << 1_i16 << EXP_BITS) - 1;
+/// Inner repetitions.
+const INNER: usize = 10000;
+/// Outer repetitions.
+const OUTER: usize = 10000;
 
-		assert!(
-			time_stamp >= 0.0,
-			"can not convert float seconds to Duration: value is negative"
-		);
-
-		let bits = time_stamp.to_bits();
-		let mant = (bits & MANT_MASK) | (MANT_MASK + 1);
-		let exp = ((bits >> MANT_BITS) & EXP_MASK) as i16 + MIN_EXP;
-
-		// CHANGED: 31 to 21 bits, because the fractional part only handles
-		// microseconds, not milliseconds.
-		let (millis, mut nanos) = if exp < -21 {
-			// the input represents less than 1ns and can not be rounded to it
-			// CHANGED: Return early.
-			return Duration::ZERO;
-		} else if exp < 0 {
-			// the input is less than 1 millisecond
-			let t = <u128>::from(mant) << (OFFSET + exp);
-			let nanos_offset = MANT_BITS + OFFSET;
-			let nanos_tmp = u128::from(NANOS_PER_MILLI) * t;
-			let nanos = (nanos_tmp >> nanos_offset) as u32;
-
-			let rem_mask = (1 << nanos_offset) - 1;
-			let rem_msb_mask = 1 << (nanos_offset - 1);
-			let rem = nanos_tmp & rem_mask;
-			let is_tie = rem == rem_msb_mask;
-			let is_even = (nanos & 1) == 0;
-			let rem_msb = nanos_tmp & rem_msb_mask == 0;
-			let add_ns = !(rem_msb || (is_even && is_tie));
-
-			let nanos = nanos + u32::from(add_ns);
-			// CHANGED: Removed `f32` handling.
-			// CHANGED: Return early.
-			#[allow(clippy::if_not_else)]
-			return if nanos != NANOS_PER_MILLI {
-				Duration::new(0, nanos)
-			} else {
-				// CHANGED: Do second to millisecond conversion right here because of the early
-				// return.
-				Duration::from_millis(1)
-			};
-		} else if exp < MANT_BITS {
-			let millis = mant >> (MANT_BITS - exp);
-			let t = <u128>::from((mant << exp) & MANT_MASK);
-			let nanos_offset = MANT_BITS;
-			let nanos_tmp = <u128>::from(NANOS_PER_MILLI) * t;
-			let nanos = (nanos_tmp >> nanos_offset) as u32;
-
-			let rem_mask = (1 << nanos_offset) - 1;
-			let rem_msb_mask = 1 << (nanos_offset - 1);
-			let rem = nanos_tmp & rem_mask;
-			let is_tie = rem == rem_msb_mask;
-			let is_even = (nanos & 1) == 0;
-			let rem_msb = nanos_tmp & rem_msb_mask == 0;
-			let add_ns = !(rem_msb || (is_even && is_tie));
-
-			let nanos = nanos + u32::from(add_ns);
-			// CHANGED: Removed `f32` handling.
-			#[allow(clippy::if_not_else)]
-			if nanos != NANOS_PER_MILLI {
-				(millis, nanos)
-			} else {
-				(millis + 1, 0)
-			}
-		}
-		// NOTE: Theoretically milliseconds can be bigger then `u64` when trying to cover
-		// `Duration::MAX`, but `Performance.now` is a monotonic clock, so we don't need to cover
-		// that.
-		else if exp < 64 {
-			// the input has no fractional part
-			let millis = mant << (exp - MANT_BITS);
-			(millis, 0)
-		} else {
-			panic!("can not convert float seconds to Duration: value is either too big or NaN")
-		};
-
-		let secs = millis / 1000;
-		let carry = millis - secs * 1000;
-		let extra_nanos = carry * u64::from(NANOS_PER_MILLI);
-		nanos += extra_nanos as u32;
-
-		debug_assert!(
-			nanos < 1_000_000_000,
-			"impossible amount of nanoseconds found"
-		);
-
-		Duration::new(secs, nanos)
-	}
-
-	thread_local! {
-		static PERFORMANCE: Performance = web_sys::window().unwrap().performance().unwrap();
-	}
-
+/// Main function.
+#[cfg_attr(not(feature = "std"), wasm_bindgen::prelude::wasm_bindgen(main))]
+pub fn main() {
 	let window = web_sys::window().unwrap();
+	let performance = window.performance().unwrap();
 	let document = window.document().unwrap();
 	let body = document.body().unwrap();
 	let table: HtmlTableElement = document.create_element("table").unwrap().unchecked_into();
 	table.set_id("benchmark");
 	body.append_child(&table).unwrap();
 
-	let benchmark = |name: &str, f: fn(f64) -> Duration| {
+	let benchmark = |name: &str, run: fn(f64) -> Duration| {
+		let performance = performance.clone();
 		let table = table.clone();
 		let name = name.to_owned();
 
 		let closure = Closure::once_into_js(move || {
-			let mut random = rand::thread_rng().sample_iter(Uniform::new_inclusive(
-				0.,
-				285_616. * 365. * 24. * 60. * 60. * 1000.,
-			));
+			// Range to maximum accurately representable integer.
+			let mut random = StdRng::from_rng(OsRng)
+				.unwrap()
+				.sample_iter(Uniform::new_inclusive(
+					0.,
+					F64(2.).powi(i32::try_from(f64::MANTISSA_DIGITS).unwrap()),
+				));
 
 			let mut time = 0.;
 
-			for _ in 0..10_000 {
-				let time_stamps: [f64; 10_000] = array::from_fn(|_| random.next().unwrap());
+			for _ in 0..OUTER {
+				let time_stamps: [f64; INNER] = array::from_fn(|_| random.next().unwrap());
 
-				let start = PERFORMANCE.with(Performance::now);
+				let start = performance.now();
 
 				for time_stamp in time_stamps {
-					hint::black_box(f(hint::black_box(time_stamp)));
+					hint::black_box(run(hint::black_box(time_stamp)));
 				}
 
-				time += PERFORMANCE.with(Performance::now) - start;
+				time += performance.now() - start;
 			}
 
-			let time = time / 100.;
+			let time = time / const { ((INNER * OUTER) / 1_000_000) as f64 };
 
 			let row: HtmlTableRowElement = table.insert_row().unwrap().unchecked_into();
 			let cell = row.insert_cell().unwrap();
@@ -180,27 +90,202 @@ fn main() {
 			.unwrap();
 	};
 
-	benchmark("custom `f64` conversion", custom_conversion);
+	benchmark("custom `f64` conversion", adjusted_std);
 	benchmark("`Duration::from_millis()`", |time_stamp| {
-		Duration::from_millis(time_stamp.trunc() as u64)
-			+ Duration::from_nanos((time_stamp.fract() * 1.0e6) as u64)
+		Duration::from_millis(F64(time_stamp).trunc() as u64)
+			+ Duration::from_nanos((F64(time_stamp).fract() * 1.0e6) as u64)
 	});
 	benchmark("`Duration::from_millis()` with rounding", |time_stamp| {
-		Duration::from_millis(time_stamp.trunc() as u64)
-			+ Duration::from_nanos((time_stamp.fract() * 1.0e6).round() as u64)
+		Duration::from_millis(F64(time_stamp).trunc() as u64)
+			+ Duration::from_nanos(F64(F64(time_stamp).fract() * 1.0e6).round() as u64)
 	});
 	benchmark("`Duration::from_secs_f64()`", |time_stamp| {
 		Duration::from_secs_f64(time_stamp) / 1000
 	});
 	benchmark("`Duration::from_secs_f64()` with rounding", |time_stamp| {
+		// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#657-668>.
 		let time_stamp = Duration::from_secs_f64(time_stamp);
 		let secs = time_stamp.as_secs() / 1000;
 		let carry = time_stamp.as_secs() - secs * 1000;
-		#[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
 		let extra_nanos = (carry * 1_000_000_000 / 1000) as u32;
 		let nanos = time_stamp.subsec_micros()
 			+ u32::from(time_stamp.subsec_nanos() % 1000 > 499)
 			+ extra_nanos;
 		Duration::new(secs, nanos)
 	});
+}
+
+/// [`f64`] `no_std` compatibility wrapper.
+#[derive(Clone, Copy)]
+struct F64(f64);
+
+impl F64 {
+	/// See [`f64::trunc()`].
+	#[cfg(feature = "std")]
+	#[expect(
+		clippy::disallowed_methods,
+		reason = "this is where the abstraction happens"
+	)]
+	fn trunc(self) -> f64 {
+		self.0.trunc()
+	}
+
+	#[cfg(not(feature = "std"))]
+	#[expect(clippy::missing_const_for_fn, reason = "compatibility with `std`")]
+	fn trunc(self) -> f64 {
+		SoftF64(self.0).trunc().0
+	}
+
+	/// See [`f64::fract()`].
+	#[cfg(feature = "std")]
+	#[expect(
+		clippy::disallowed_methods,
+		reason = "this is where the abstraction happens"
+	)]
+	fn fract(self) -> f64 {
+		self.0.fract()
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fract(self) -> f64 {
+		self.0 - self.trunc()
+	}
+
+	/// See [`f64::round()`].
+	#[cfg(feature = "std")]
+	#[expect(
+		clippy::disallowed_methods,
+		reason = "this is where the abstraction happens"
+	)]
+	#[cfg(feature = "std")]
+	fn round(self) -> f64 {
+		self.0.round()
+	}
+
+	#[cfg(not(feature = "std"))]
+	#[expect(clippy::missing_const_for_fn, reason = "compatibility with `std`")]
+	fn round(self) -> f64 {
+		SoftF64(self.0).round().0
+	}
+
+	/// See [`f64::powi()`].
+	#[cfg(feature = "std")]
+	#[expect(
+		clippy::disallowed_methods,
+		reason = "this is where the abstraction happens"
+	)]
+	fn powi(self, n: i32) -> f64 {
+		self.0.powi(n)
+	}
+
+	#[cfg(not(feature = "std"))]
+	#[expect(clippy::missing_const_for_fn, reason = "compatibility with `std`")]
+	fn powi(self, n: i32) -> f64 {
+		SoftF64(self.0).powi(n).0
+	}
+}
+
+/// Adjusted [`Duration::from_secs_f64()`].
+///
+/// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#1262-1340>.
+#[expect(warnings, reason = "code is copied")]
+fn adjusted_std(time_stamp: f64) -> Duration {
+	// CHANGED: 1G to 1M.
+	const NANOS_PER_MILLI: u32 = 1_000_000;
+
+	// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#1477-1484>.
+	const MANT_BITS: i16 = 52;
+	const EXP_BITS: i16 = 11;
+	const OFFSET: i16 = 44;
+
+	// See <https://doc.rust-lang.org/1.73.0/src/core/time.rs.html#1262-1340>.
+	const MIN_EXP: i16 = 1 - (1_i16 << EXP_BITS) / 2;
+	const MANT_MASK: u64 = (1 << MANT_BITS) - 1;
+	const EXP_MASK: u64 = (1 << 1_i16 << EXP_BITS) - 1;
+
+	assert!(
+		time_stamp >= 0.0,
+		"can not convert float seconds to Duration: value is negative"
+	);
+
+	let bits = time_stamp.to_bits();
+	let mant = (bits & MANT_MASK) | (MANT_MASK + 1);
+	let exp = ((bits >> MANT_BITS) & EXP_MASK) as i16 + MIN_EXP;
+
+	// CHANGED: 31 to 21 bits, because the fractional part only handles
+	// microseconds, not milliseconds.
+	let (millis, mut nanos) = if exp < -21 {
+		// the input represents less than 1ns and can not be rounded to it
+		// CHANGED: Return early.
+		return Duration::ZERO;
+	} else if exp < 0 {
+		// the input is less than 1 millisecond
+		let t = <u128>::from(mant) << (OFFSET + exp);
+		let nanos_offset = MANT_BITS + OFFSET;
+		let nanos_tmp = u128::from(NANOS_PER_MILLI) * t;
+		let nanos = (nanos_tmp >> nanos_offset) as u32;
+
+		let rem_mask = (1 << nanos_offset) - 1;
+		let rem_msb_mask = 1 << (nanos_offset - 1);
+		let rem = nanos_tmp & rem_mask;
+		let is_tie = rem == rem_msb_mask;
+		let is_even = (nanos & 1) == 0;
+		let rem_msb = nanos_tmp & rem_msb_mask == 0;
+		let add_ns = !(rem_msb || (is_even && is_tie));
+
+		let nanos = nanos + u32::from(add_ns);
+		// CHANGED: Removed `f32` handling.
+		// CHANGED: Return early.
+		return if nanos != NANOS_PER_MILLI {
+			Duration::new(0, nanos)
+		} else {
+			// CHANGED: Do second to millisecond conversion right here because of the early
+			// return.
+			Duration::from_millis(1)
+		};
+	} else if exp < MANT_BITS {
+		let millis = mant >> (MANT_BITS - exp);
+		let t = <u128>::from((mant << exp) & MANT_MASK);
+		let nanos_offset = MANT_BITS;
+		let nanos_tmp = <u128>::from(NANOS_PER_MILLI) * t;
+		let nanos = (nanos_tmp >> nanos_offset) as u32;
+
+		let rem_mask = (1 << nanos_offset) - 1;
+		let rem_msb_mask = 1 << (nanos_offset - 1);
+		let rem = nanos_tmp & rem_mask;
+		let is_tie = rem == rem_msb_mask;
+		let is_even = (nanos & 1) == 0;
+		let rem_msb = nanos_tmp & rem_msb_mask == 0;
+		let add_ns = !(rem_msb || (is_even && is_tie));
+
+		let nanos = nanos + u32::from(add_ns);
+		// CHANGED: Removed `f32` handling.
+		if nanos != NANOS_PER_MILLI {
+			(millis, nanos)
+		} else {
+			(millis + 1, 0)
+		}
+	}
+	// NOTE: Theoretically milliseconds can be bigger then `u64` when trying to cover
+	// `Duration::MAX`, but `Performance.now` is a monotonic clock, so we don't need to cover
+	// that.
+	else if exp < 64 {
+		// the input has no fractional part
+		let millis = mant << (exp - MANT_BITS);
+		(millis, 0)
+	} else {
+		panic!("can not convert float seconds to Duration: value is either too big or NaN")
+	};
+
+	let secs = millis / 1000;
+	let carry = millis - secs * 1000;
+	let extra_nanos = carry * u64::from(NANOS_PER_MILLI);
+	nanos += extra_nanos as u32;
+
+	debug_assert!(
+		nanos < 1_000_000_000,
+		"impossible amount of nanoseconds found"
+	);
+
+	Duration::new(secs, nanos)
 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,11 @@
 allow-renamed-params-for = ["..", "core::fmt::Debug", "core::fmt::Display"]
 allow-unwrap-in-tests = true
 avoid-breaking-exported-api = false
+disallowed-methods = [
+	{ path = "f64::trunc", reason = "not available on `no_std`" },
+	{ path = "f64::fract", reason = "not available on `no_std`" },
+	{ path = "f64::copysign", reason = "not available on `no_std`" },
+	{ path = "f64::round", reason = "not available on `no_std`" },
+	{ path = "f64::powi", reason = "not available on `no_std`" },
+]
 semicolon-outside-block-ignore-multiline = true

--- a/minimal-versions/Cargo.toml
+++ b/minimal-versions/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 edition = "2021"
 name = "minimal-versions"
@@ -5,5 +7,10 @@ publish = false
 rust-version = "1.60"
 version = "0.0.0"
 
+[features]
+default = ["std"]
+serde = ["web-time/serde"]
+std = ["web-time/std"]
+
 [dependencies]
-web-time = { path = ".." }
+web-time = { path = "..", default-features = false }

--- a/minimal-versions/src/lib.rs
+++ b/minimal-versions/src/lib.rs
@@ -1,1 +1,3 @@
 //! Testing minimal versions of dependencies.
+
+#![cfg_attr(not(feature = "std"), no_std)]

--- a/src/time/js.rs
+++ b/src/time/js.rs
@@ -1,5 +1,7 @@
 //! Bindings to the JS API.
 
+#[cfg(not(feature = "std"))]
+use once_cell::unsync::Lazy;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -13,20 +15,24 @@ extern "C" {
 	fn performance(this: &Global) -> JsValue;
 
 	/// Type for the [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
-	pub(super) type Performance;
+	type JsPerformance;
 
 	/// Binding to [`Performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now).
 	#[wasm_bindgen(method)]
-	pub(super) fn now(this: &Performance) -> f64;
+	fn now(this: &JsPerformance) -> f64;
 
 	/// Binding to [`Performance.timeOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin).
 	#[cfg(target_feature = "atomics")]
 	#[wasm_bindgen(method, getter, js_name = timeOrigin)]
-	pub(super) fn time_origin(this: &Performance) -> f64;
+	fn time_origin(this: &JsPerformance) -> f64;
 }
 
-thread_local! {
-	pub(super) static PERFORMANCE: Performance = {
+/// Cached [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+pub(super) struct Performance;
+
+impl Performance {
+	/// Create the [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+	fn init() -> JsPerformance {
 		let global: Global = js_sys::global().unchecked_into();
 		let performance = global.performance();
 
@@ -35,5 +41,74 @@ thread_local! {
 		} else {
 			performance.unchecked_into()
 		}
-	};
+	}
+
+	/// Access to the underlying [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+	#[cfg(feature = "std")]
+	fn with<R>(fun: impl FnOnce(&JsPerformance) -> R) -> R {
+		thread_local! {
+			static PERFORMANCE: JsPerformance = Performance::init();
+		}
+
+		PERFORMANCE.with(fun)
+	}
+
+	/// Access to the underlying [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+	#[cfg(not(feature = "std"))]
+	fn with<R>(fun: impl FnOnce(&JsPerformance) -> R) -> R {
+		/// `Send + Sync` wrapper for [`Lazy`].
+		struct Wrapper<T>(T);
+
+		#[cfg(not(target_feature = "atomics"))]
+		#[allow(clippy::non_send_fields_in_send_ty, unsafe_code)]
+		// SAFETY: only when no threads are supported.
+		unsafe impl<T> Send for Wrapper<T> {}
+		#[cfg(not(target_feature = "atomics"))]
+		#[allow(clippy::non_send_fields_in_send_ty, unsafe_code)]
+		// SAFETY: only when no threads are supported.
+		unsafe impl<T> Sync for Wrapper<T> {}
+
+		/// Cached [`Performance` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+		#[cfg_attr(target_feature = "atomics", thread_local)]
+		static PERFORMANCE: Wrapper<Lazy<JsPerformance>> = Wrapper(Lazy::new(Performance::init));
+
+		#[allow(unsafe_code)]
+		fun(&PERFORMANCE.0)
+	}
+
+	/// Calls [`Performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now).
+	pub(super) fn now() -> f64 {
+		Self::with(JsPerformance::now)
+	}
+}
+
+/// Cached [`Performance.timeOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin).
+#[cfg(target_feature = "atomics")]
+pub(super) struct Origin;
+
+#[cfg(target_feature = "atomics")]
+impl Origin {
+	/// Get [`Performance.timeOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin).
+	fn init() -> f64 {
+		Performance::with(JsPerformance::time_origin)
+	}
+
+	/// Returns [`Performance.timeOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin).
+	#[cfg(feature = "std")]
+	pub(super) fn get() -> f64 {
+		thread_local! {
+			static ORIGIN: f64 = Origin::init();
+		}
+
+		ORIGIN.with(|origin| *origin)
+	}
+
+	/// Returns [`Performance.timeOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin).
+	#[cfg(not(feature = "std"))]
+	pub(super) fn get() -> f64 {
+		#[thread_local]
+		static ORIGIN: Lazy<f64> = Lazy::new(Origin::init);
+
+		*ORIGIN
+	}
 }

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,4 +1,9 @@
 //! Re-implementation of [`std::time`].
+#![cfg_attr(
+	not(feature = "std"),
+	doc = "",
+	doc = "[`std::time`]: https://doc.rust-lang.org/std/time"
+)]
 
 mod instant;
 mod js;
@@ -6,10 +11,18 @@ mod js;
 mod serde;
 mod system_time;
 
+#[cfg(not(feature = "std"))]
+pub use core::time::*;
+#[cfg(feature = "std")]
 pub use std::time::*;
 
 pub use self::instant::Instant;
 pub use self::system_time::{SystemTime, SystemTimeError};
 
 /// See [`std::time::UNIX_EPOCH`].
+#[cfg_attr(
+	not(feature = "std"),
+	doc = "",
+	doc = "[`std::time::UNIX_EPOCH`]: https://doc.rust-lang.org/std/time/constant.UNIX_EPOCH.html"
+)]
 pub const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;

--- a/src/time/serde.rs
+++ b/src/time/serde.rs
@@ -4,21 +4,25 @@
 //! This implementation was copied from Serde's
 //! [`Deserialize`](https://github.com/serde-rs/serde/blob/5fa711d75d91173aafc6019e03cf8af6ac9ba7b2/serde/src/de/impls.rs#L2168-L2314),
 //! and
-//! [`Sserialize`](https://github.com/serde-rs/serde/blob/5fa711d75d91173aafc6019e03cf8af6ac9ba7b2/serde/src/ser/impls.rs#L730-L747)
+//! [`Serialize`](https://github.com/serde-rs/serde/blob/5fa711d75d91173aafc6019e03cf8af6ac9ba7b2/serde/src/ser/impls.rs#L730-L747)
 //! implementation.
 
 #![allow(warnings)]
 
 // CHANGED: Replaced occurrences of `tri!` macro with `?`.
 
-use std::fmt;
-use std::time::Duration;
+extern crate alloc;
+
+use alloc::string::String;
+use core::fmt;
+use core::time::Duration;
 
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::SystemTime;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for SystemTime {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -161,6 +165,7 @@ impl<'de> Deserialize<'de> for SystemTime {
 	}
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for SystemTime {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where

--- a/src/time/system_time.rs
+++ b/src/time/system_time.rs
@@ -1,19 +1,43 @@
 //! Re-implementation of [`std::time::SystemTime`].
 
+#![cfg_attr(
+	not(feature = "std"),
+	doc = "",
+	doc = "[`std::time::SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html"
+)]
+
+#[cfg(all(doc, not(feature = "std")))]
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::time::Duration;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-use std::time::Duration;
 
 /// See [`std::time::SystemTime`].
+#[cfg_attr(
+	not(feature = "std"),
+	doc = "",
+	doc = "[`std::time::SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html"
+)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SystemTime(pub(crate) Duration);
 
 impl SystemTime {
 	/// See [`std::time::SystemTime::UNIX_EPOCH`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::UNIX_EPOCH`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#associatedconstant.UNIX_EPOCH"
+	)]
 	pub const UNIX_EPOCH: Self = Self(Duration::ZERO);
 
 	/// See [`std::time::SystemTime::now()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::now()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now"
+	)]
 	#[must_use]
 	#[allow(clippy::missing_panics_doc)]
 	pub fn now() -> Self {
@@ -25,6 +49,11 @@ impl SystemTime {
 	}
 
 	/// See [`std::time::SystemTime::duration_since()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::duration_since()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.duration_since"
+	)]
 	#[allow(clippy::missing_errors_doc, clippy::trivially_copy_pass_by_ref)]
 	pub fn duration_since(&self, earlier: Self) -> Result<Duration, SystemTimeError> {
 		if self.0 < earlier.0 {
@@ -35,18 +64,33 @@ impl SystemTime {
 	}
 
 	/// See [`std::time::SystemTime::elapsed()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::elapsed()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.elapsed"
+	)]
 	#[allow(clippy::missing_errors_doc, clippy::trivially_copy_pass_by_ref)]
 	pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
 		Self::now().duration_since(*self)
 	}
 
 	/// See [`std::time::SystemTime::checked_add()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::checked_add()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.checked_add"
+	)]
 	#[allow(clippy::trivially_copy_pass_by_ref)]
 	pub fn checked_add(&self, duration: Duration) -> Option<Self> {
 		self.0.checked_add(duration).map(SystemTime)
 	}
 
 	/// See [`std::time::SystemTime::checked_sub()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTime::checked_sub()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.checked_sub"
+	)]
 	#[allow(clippy::trivially_copy_pass_by_ref)]
 	pub fn checked_sub(&self, duration: Duration) -> Option<Self> {
 		self.0.checked_sub(duration).map(SystemTime)
@@ -89,12 +133,22 @@ impl SubAssign<Duration> for SystemTime {
 }
 
 /// See [`std::time::SystemTimeError`].
+#[cfg_attr(
+	not(feature = "std"),
+	doc = "",
+	doc = "[`std::time::SystemTimeError`]: https://doc.rust-lang.org/std/time/struct.SystemTimeError.html"
+)]
 #[derive(Clone, Debug)]
 #[allow(missing_copy_implementations)]
 pub struct SystemTimeError(Duration);
 
 impl SystemTimeError {
 	/// See [`std::time::SystemTimeError::duration()`].
+	#[cfg_attr(
+		not(feature = "std"),
+		doc = "",
+		doc = "[`std::time::SystemTimeError::duration()`]: https://doc.rust-lang.org/std/time/struct.SystemTimeError.html#method.duration"
+	)]
 	#[must_use]
 	#[allow(clippy::missing_const_for_fn)]
 	pub fn duration(&self) -> Duration {
@@ -108,4 +162,6 @@ impl Display for SystemTimeError {
 	}
 }
 
+#[cfg(any(feature = "std", docsrs))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Error for SystemTimeError {}

--- a/src/web.rs
+++ b/src/web.rs
@@ -6,6 +6,18 @@ use std::time::SystemTime as StdSystemTime;
 
 use crate::SystemTime;
 
+#[cfg(all(
+	target_family = "wasm",
+	any(target_os = "unknown", target_os = "none"),
+	not(feature = "std"),
+))]
+#[doc(hidden)]
+mod std {
+	pub mod time {
+		pub struct SystemTime;
+	}
+}
+
 /// Web-specific extension to [`web_time::SystemTime`](crate::SystemTime).
 pub trait SystemTimeExt {
 	/// Convert [`web_time::SystemTime`](crate::SystemTime) to
@@ -19,6 +31,16 @@ pub trait SystemTimeExt {
 	/// incompatible APIs of other dependencies, care should be taken that the
 	/// dependency in question doesn't call [`std::time::SystemTime::now()`]
 	/// internally, which would panic.
+	#[cfg_attr(
+		all(
+			target_family = "wasm",
+			any(target_os = "unknown", target_os = "none"),
+			not(feature = "std"),
+		),
+		doc = "",
+		doc = "[`std::time::SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html",
+		doc = "[`std::time::SystemTime::now()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now"
+	)]
 	fn to_std(self) -> std::time::SystemTime;
 
 	/// Convert [`std::time::SystemTime`] to
@@ -32,6 +54,16 @@ pub trait SystemTimeExt {
 	/// incompatible APIs of other dependencies, care should be taken that the
 	/// dependency in question doesn't call [`std::time::SystemTime::now()`]
 	/// internally, which would panic.
+	#[cfg_attr(
+		all(
+			target_family = "wasm",
+			any(target_os = "unknown", target_os = "none"),
+			not(feature = "std"),
+		),
+		doc = "",
+		doc = "[`std::time::SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html",
+		doc = "[`std::time::SystemTime::now()`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now"
+	)]
 	fn from_std(time: std::time::SystemTime) -> SystemTime;
 }
 

--- a/tests-native/Cargo.toml
+++ b/tests-native/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+autobenches = false
+edition = "2021"
+name = "tests-native"
+publish = false
+version = "0.0.0"
+
+[features]
+default = ["std"]
+run = []
+std = ["tests-web/std", "web-time/std"]
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tests-web = { path = "../tests-web", default-features = false }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pollster = { version = "0.4", features = ["macro"] }
+serde-json-core = { version = "0.6", default-features = false, features = ["std"] }
+serde_json = "1"
+serde_test = "1"
+static_assertions = "1"
+wasm-bindgen-test = { version = "0.3" }
+web-time = { path = "../", default-features = false }
+
+[lib]
+doctest = false
+harness = false
+test = false
+
+[[test]]
+name = "native_instant_failure_1"
+path = "../tests/instant_failure_1.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_instant_failure_2"
+path = "../tests/instant_failure_2.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_instant_success"
+path = "../tests/instant_success.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_serde"
+path = "../tests/serde.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_system_time_failure_1"
+path = "../tests/system_time_failure_1.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_system_time_failure_2"
+path = "../tests/system_time_failure_2.rs"
+required-features = ["run"]
+
+[[test]]
+name = "native_system_time_success"
+path = "../tests/system_time_success.rs"
+required-features = ["run"]
+
+[[test]]
+name = "traits"
+path = "../tests/traits.rs"
+required-features = ["run"]
+
+[lints]
+workspace = true

--- a/tests-native/src/lib.rs
+++ b/tests-native/src/lib.rs
@@ -1,0 +1,10 @@
+//! A crate for running tests on native with the default test harness.
+
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
+#![cfg_attr(all(test, target_family = "wasm"), no_main)]
+
+#[cfg(all(test, target_family = "wasm"))]
+use tests_web as _;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+fn main() {}

--- a/tests-web/Cargo.toml
+++ b/tests-web/Cargo.toml
@@ -1,0 +1,144 @@
+[package]
+autobenches = false
+edition = "2021"
+name = "tests-web"
+publish = false
+version = "0.0.0"
+
+[features]
+default = ["std"]
+run = []
+serde = ["serde_test", "serde_json", "serde-json-core"]
+std = [
+	"wasm-bindgen/std",
+	"js-sys/std",
+	"web-sys/std",
+	"wasm-bindgen-futures/std",
+	"wasm-bindgen-test/std",
+	"serde_test?/std",
+	"serde_json?/std",
+	"serde-json-core?/std",
+	"getrandom/std",
+	"rand/std",
+	"once_cell/std",
+	"futures-util/std",
+	"futures-channel/std",
+	"web-thread",
+	"web-time/std",
+]
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+const_soft_float = { version = "0.1", features = ["no_std"] }
+dlmalloc = "0.2"
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = { version = "0.3", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
+serde-json-core = { version = "0.6", optional = true, default-features = false }
+serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+serde_test = { version = "1", optional = true, default-features = false }
+static_assertions = "1"
+wasm-bindgen = { version = "0.2", default-features = false }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-test = { version = "0.3", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = [
+	"CssStyleDeclaration",
+	"Document",
+	"Element",
+	"HtmlTableElement",
+	"HtmlTableRowElement",
+	"Performance",
+	"Window",
+] }
+web-time = { path = "../", default-features = false }
+
+[target.'cfg(all(target_family = "wasm", target_feature = "atomics"))'.dependencies]
+critical-section = { version = "1", features = ["restore-state-bool"] }
+futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3", default-features = false }
+once_cell = { version = "1", default-features = false, features = ["critical-section"] }
+web-sys = { version = "0.3", default-features = false, features = [
+	"DedicatedWorkerGlobalScope",
+	"OfflineAudioContext",
+	"WorkerGlobalScope",
+] }
+web-thread = { git = "https://github.com/daxpedda/wasm-worker", rev = "93236ab92354cbe0a0c07e71b9888be8b3e45999", optional = true, features = [
+	"audio-worklet",
+] }
+
+[lib]
+doctest = false
+harness = false
+test = false
+
+[[example]]
+harness = false
+name = "benchmark"
+path = "../benches/benchmark.rs"
+required-features = ["run"]
+test = false
+
+[[test]]
+name = "atomic_failure"
+path = "../tests/atomic_failure.rs"
+required-features = ["std", "run"]
+
+[[test]]
+name = "atomic_success"
+path = "../tests/atomic_success.rs"
+required-features = ["std", "run"]
+
+[[test]]
+harness = false
+name = "web_instant_failure_1"
+path = "../tests/instant_failure_1.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_instant_failure_2"
+path = "../tests/instant_failure_2.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_instant_success"
+path = "../tests/instant_success.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_serde"
+path = "../tests/serde.rs"
+required-features = ["serde", "run"]
+
+[[test]]
+harness = false
+name = "web_system_time_failure_1"
+path = "../tests/system_time_failure_1.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_system_time_failure_2"
+path = "../tests/system_time_failure_2.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_system_time_success"
+path = "../tests/system_time_success.rs"
+required-features = ["run"]
+
+[[test]]
+harness = false
+name = "web_traits"
+path = "../tests/traits.rs"
+required-features = ["run"]
+
+[[test]]
+name = "web"
+path = "../tests/web.rs"
+required-features = ["std", "run"]
+
+[lints]
+workspace = true

--- a/tests-web/src/lib.rs
+++ b/tests-web/src/lib.rs
@@ -1,0 +1,161 @@
+//! A crate for running tests on Web without the default test harness.
+
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
+#![cfg_attr(all(test, target_family = "wasm"), no_main)]
+#![cfg_attr(
+	all(target_family = "wasm", target_feature = "atomics"),
+	feature(thread_local)
+)]
+
+#[cfg(all(target_family = "wasm", not(feature = "std")))]
+use wasm_bindgen_test as _;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+fn main() {}
+
+#[cfg(all(target_family = "wasm", not(feature = "std")))]
+#[expect(
+	unsafe_code,
+	reason = "no way to implement `GlobalAlloc` without unsafe"
+)]
+mod allocator {
+	//! Implementing [`GlobalAlloc`].
+	//!
+	//! See <https://github.com/rust-lang/rust/blob/1.82.0/library/std/src/sys/alloc/wasm.rs>.
+
+	use core::alloc::{GlobalAlloc, Layout};
+	use core::sync::atomic::{AtomicBool, Ordering};
+
+	/// The allocator.
+	static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::Dlmalloc::new();
+	/// The lock flag.
+	static LOCKED: AtomicBool = AtomicBool::new(false);
+	/// Global allocator.
+	#[global_allocator]
+	static ALLOC: System = System;
+
+	/// Implementing [`GlobalAlloc`].
+	struct System;
+
+	// SAFETY: we mostly rely on `dlmalloc` for safety.
+	unsafe impl GlobalAlloc for System {
+		#[inline]
+		unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+			let _lock = lock();
+			// SAFETY: `DLMALLOC` access is guaranteed to be safe because the lock gives us
+			// unique and non-reentrant access. Calling `malloc()` is safe because
+			// preconditions on this function match the trait method preconditions.
+			unsafe { (*core::ptr::addr_of_mut!(DLMALLOC)).malloc(layout.size(), layout.align()) }
+		}
+
+		#[inline]
+		unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+			let _lock = lock();
+			// SAFETY: `DLMALLOC` access is guaranteed to be safe because the lock gives us
+			// unique and non-reentrant access. Calling `calloc()` is safe because
+			// preconditions on this function match the trait method preconditions.
+			unsafe { (*core::ptr::addr_of_mut!(DLMALLOC)).calloc(layout.size(), layout.align()) }
+		}
+
+		#[inline]
+		unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+			let _lock = lock();
+			// SAFETY: `DLMALLOC` access is guaranteed to be safe because the lock gives us
+			// unique and non-reentrant access. Calling `free()` is safe because
+			// preconditions on this function match the trait method preconditions.
+			unsafe { (*core::ptr::addr_of_mut!(DLMALLOC)).free(ptr, layout.size(), layout.align()) }
+		}
+
+		#[inline]
+		unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+			let _lock = lock();
+			// SAFETY: `DLMALLOC` access is guaranteed to be safe because the lock gives us
+			// unique and non-reentrant access. Calling `realloc()` is safe because
+			// preconditions on this function match the trait method preconditions.
+			unsafe {
+				(*core::ptr::addr_of_mut!(DLMALLOC)).realloc(
+					ptr,
+					layout.size(),
+					layout.align(),
+					new_size,
+				)
+			}
+		}
+	}
+
+	/// The lock guard.
+	struct DropLock;
+
+	/// Create a [`DropLock`].
+	fn lock() -> DropLock {
+		while LOCKED
+			.compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+			.is_err()
+		{}
+
+		DropLock
+	}
+
+	impl Drop for DropLock {
+		fn drop(&mut self) {
+			LOCKED.swap(false, Ordering::Release);
+		}
+	}
+}
+
+#[cfg(all(target_family = "wasm", target_feature = "atomics"))]
+#[expect(
+	unsafe_code,
+	reason = "no way to implement `critical_section` without unsafe"
+)]
+#[expect(
+	clippy::no_mangle_with_rust_abi,
+	reason = "from `critical_section::set_impl!` macro"
+)]
+mod critical_section {
+	//! Implementing [`critical_section`].
+
+	use core::cell::Cell;
+	use core::sync::atomic::{AtomicBool, Ordering};
+
+	use critical_section::Impl;
+
+	/// The lock flag.
+	static LOCKED: AtomicBool = AtomicBool::new(false);
+	/// The thread local lock flag.
+	#[thread_local]
+	static LOCAL_LOCKED: Cell<bool> = Cell::new(false);
+
+	critical_section::set_impl!(CriticalSection);
+
+	/// Implementing [`critical_section::Impl`].
+	struct CriticalSection;
+
+	// SAFETY: the lock is safely implemented.
+	unsafe impl Impl for CriticalSection {
+		#[inline]
+		unsafe fn acquire() -> bool {
+			if LOCAL_LOCKED.get() {
+				return true;
+			}
+
+			LOCAL_LOCKED.set(true);
+
+			while LOCKED
+				.compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+				.is_err()
+			{}
+
+			false
+		}
+
+		#[inline]
+		unsafe fn release(restore_state: bool) {
+			if !restore_state {
+				LOCKED.store(false, Ordering::Release);
+
+				LOCAL_LOCKED.set(false);
+			}
+		}
+	}
+}

--- a/tests/atomic_failure.rs
+++ b/tests/atomic_failure.rs
@@ -1,22 +1,20 @@
 //! Run tests with the atomics target feature.
 
 #![cfg(test)]
-#![cfg(all(target_family = "wasm", target_feature = "atomics"))]
+#![cfg(target_feature = "atomics")]
 
 mod util;
 
 use futures_util::future;
 use futures_util::future::Either;
-use util::MAX_DIFF;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_sys::OfflineAudioContext;
 use web_thread::web::audio_worklet::BaseAudioContextExt;
 use web_time::Instant;
 
-use self::util::Flag;
+use self::util::{Flag, MAX_DIFF};
 
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
+/// Testing failure of [`Instant::now()`] in audio worklet.
 #[wasm_bindgen_test]
 async fn test() {
 	let context =

--- a/tests/atomic_success.rs
+++ b/tests/atomic_success.rs
@@ -1,7 +1,7 @@
 //! Run tests with the atomics target feature.
 
 #![cfg(test)]
-#![cfg(all(target_family = "wasm", target_feature = "atomics"))]
+#![cfg(target_feature = "atomics")]
 
 mod util;
 
@@ -11,8 +11,6 @@ use web_thread::web;
 use web_time::{Duration, Instant};
 
 use self::util::{sleep, Flag, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 async fn basic() {

--- a/tests/instant_failure_1.rs
+++ b/tests/instant_failure_1.rs
@@ -2,6 +2,8 @@
 //! problems with `panic = "abort"`.
 
 #![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
 
 mod util;
 
@@ -9,8 +11,6 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
 use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// [`Instant::add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
@@ -22,8 +22,12 @@ async fn add_failure() {
 
 /// [`Instant::sub()`] failure.
 #[wasm_bindgen_test(unsupported = test)]
-#[allow(clippy::unchecked_duration_subtraction)]
 #[should_panic = "overflow when subtracting duration from instant"]
+#[allow(
+	clippy::allow_attributes,
+	clippy::unchecked_duration_subtraction,
+	reason = "this is what we are testing"
+)]
 fn sub_failure() {
 	let _ = Instant::now() - Duration::MAX;
 }

--- a/tests/instant_failure_2.rs
+++ b/tests/instant_failure_2.rs
@@ -2,6 +2,8 @@
 //! problems with `panic = "abort"`.
 
 #![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
 
 mod util;
 
@@ -9,8 +11,6 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
 use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// [`Instant::add_assign()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]

--- a/tests/instant_success.rs
+++ b/tests/instant_success.rs
@@ -1,17 +1,15 @@
 //! [`Instant`] tests.
 
 #![cfg(test)]
-#![allow(clippy::missing_assert_message)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
 
 mod util;
 
-use util::MAX_DIFF;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
-use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+use self::util::{sleep, DIFF, MAX_DIFF};
 
 /// [`Instant::duration_since()`] success.
 #[wasm_bindgen_test(unsupported = pollster::test)]
@@ -136,8 +134,12 @@ async fn add_assign_success() {
 }
 
 /// [`Instant::sub()`] success.
-#[allow(clippy::unchecked_duration_subtraction)]
 #[wasm_bindgen_test(unsupported = pollster::test)]
+#[allow(
+	clippy::allow_attributes,
+	clippy::unchecked_duration_subtraction,
+	reason = "this is what we are testing"
+)]
 async fn sub_success() {
 	let instant = Instant::now();
 	sleep(DIFF).await;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,16 +1,20 @@
 //! [`serde`] tests for [`SystemTime`].
 
 #![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
+
+extern crate alloc;
 
 mod util;
 
+use alloc::string::ToString;
+#[cfg(feature = "std")]
 use std::time::{Duration, SystemTime as StdSystemTime};
 
 use serde_test::Token;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::SystemTime;
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// De/Serialization of [`SystemTime`].
 #[wasm_bindgen_test(unsupported = test)]
@@ -32,6 +36,7 @@ fn unix_epoch_json() {
 }
 
 /// De/Serialization compatibility with [`std::time::SystemTime`].
+#[cfg(feature = "std")]
 #[wasm_bindgen_test(unsupported = test)]
 fn std_compatibility_json() {
 	let time = SystemTime::now();
@@ -224,17 +229,20 @@ fn failure_map() {
 #[wasm_bindgen_test(unsupported = test)]
 fn failure_serialize() {
 	let mut serialized = [0; 0];
-	let error = serde_json::to_writer(serialized.as_mut(), &SystemTime::UNIX_EPOCH).unwrap_err();
+	let error =
+		serde_json_core::to_slice(&SystemTime::UNIX_EPOCH, serialized.as_mut()).unwrap_err();
 
-	assert_eq!(error.to_string(), "failed to write whole buffer");
+	assert_eq!(error.to_string(), "Buffer is full");
 
 	let mut serialized = [0; 1];
-	let error = serde_json::to_writer(serialized.as_mut(), &SystemTime::UNIX_EPOCH).unwrap_err();
+	let error =
+		serde_json_core::to_slice(&SystemTime::UNIX_EPOCH, serialized.as_mut()).unwrap_err();
 
-	assert_eq!(error.to_string(), "failed to write whole buffer");
+	assert_eq!(error.to_string(), "Buffer is full");
 
 	let mut serialized = [0; 21];
-	let error = serde_json::to_writer(serialized.as_mut(), &SystemTime::UNIX_EPOCH).unwrap_err();
+	let error =
+		serde_json_core::to_slice(&SystemTime::UNIX_EPOCH, serialized.as_mut()).unwrap_err();
 
-	assert_eq!(error.to_string(), "failed to write whole buffer");
+	assert_eq!(error.to_string(), "Buffer is full");
 }

--- a/tests/system_time_failure_1.rs
+++ b/tests/system_time_failure_1.rs
@@ -2,6 +2,8 @@
 //! problems with `panic = "abort"`.
 
 #![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
 
 mod util;
 
@@ -9,8 +11,6 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
 use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// [`SystemTime::add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]

--- a/tests/system_time_failure_2.rs
+++ b/tests/system_time_failure_2.rs
@@ -2,6 +2,8 @@
 //! problems with `panic = "abort"`.
 
 #![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
 
 mod util;
 
@@ -9,8 +11,6 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
 use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// [`SystemTime::add_assign()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]

--- a/tests/system_time_success.rs
+++ b/tests/system_time_success.rs
@@ -1,20 +1,26 @@
 //! [`SystemTime`] tests.
 
 #![cfg(test)]
-#![allow(clippy::missing_assert_message)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
+
+extern crate alloc;
 
 mod util;
 
-use util::MAX_DIFF;
+use alloc::string::ToString;
+
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
-use self::util::{sleep, DIFF};
-
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+use self::util::{sleep, DIFF, MAX_DIFF};
 
 /// [`SystemTime::UNIX_EPOCH`].
-#[allow(clippy::eq_op)]
+#[allow(
+	clippy::allow_attributes,
+	clippy::eq_op,
+	reason = "thats what we are testing"
+)]
 #[wasm_bindgen_test(unsupported = test)]
 fn unix_epoch() {
 	let time = SystemTime::UNIX_EPOCH.elapsed().unwrap();

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,19 +1,23 @@
 //! Test for traits on all exported types.
 
+#![cfg(test)]
+#![cfg_attr(target_family = "wasm", no_main)]
+#![cfg_attr(all(target_family = "wasm", not(feature = "std")), no_std)]
+
+mod util;
+
+use core::fmt::{Debug, Display};
+use core::hash::Hash;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::panic::{RefUnwindSafe, UnwindSafe};
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use static_assertions::{assert_impl_all, assert_not_impl_any};
 use web_time::{Duration, Instant, SystemTime, SystemTimeError};
 
-#[cfg(target_family = "wasm")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
-#[cfg_attr(not(target_family = "wasm"), test)]
-#[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+/// Testing all traits on all types.
+#[wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
 const fn test() {
 	assert_impl_all!(Instant: Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Send, Sync, Unpin, RefUnwindSafe, UnwindSafe);
 	assert_impl_all!(Instant: Add<Duration>, AddAssign<Duration>, Sub<Duration>, SubAssign<Duration>);
@@ -21,6 +25,8 @@ const fn test() {
 	assert_impl_all!(SystemTime: Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Send, Sync, Unpin, RefUnwindSafe, UnwindSafe);
 	assert_impl_all!(SystemTime: Add<Duration>, AddAssign<Duration>, Sub<Duration>, SubAssign<Duration>);
 
-	assert_impl_all!(SystemTimeError: Clone, Debug, Display, Error, Send, Sync, Unpin, RefUnwindSafe, UnwindSafe);
+	assert_impl_all!(SystemTimeError: Clone, Debug, Display, Send, Sync, Unpin, RefUnwindSafe, UnwindSafe);
+	#[cfg(feature = "std")]
+	assert_impl_all!(SystemTimeError: Error);
 	assert_not_impl_any!(SystemTimeError: Copy, Hash, Eq, PartialEq, Ord, PartialOrd);
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,19 +1,35 @@
+//! Utility types and functions.
+
 #[cfg(not(target_family = "wasm"))]
 mod std;
 #[cfg(target_family = "wasm")]
 mod web;
 
+#[cfg(target_family = "wasm")]
+use tests_web as _;
 use web_time::Duration;
 
 #[cfg(not(target_family = "wasm"))]
-#[allow(unused)]
+#[allow(
+	clippy::allow_attributes,
+	unused_imports,
+	reason = "not used by all tests"
+)]
 pub(crate) use self::std::*;
 #[cfg(target_family = "wasm")]
-#[allow(unused)]
+#[allow(
+	clippy::allow_attributes,
+	unused_imports,
+	reason = "not used by all tests"
+)]
 pub(crate) use self::web::*;
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+/// Difference to measure that time has passed.
 pub(crate) const DIFF: Duration = Duration::from_millis(50);
-#[allow(dead_code)]
+/// Maximum difference that can't have been passed by [`DIFF`].
+#[allow(clippy::allow_attributes, dead_code, reason = "not used by all tests")]
 pub(crate) const MAX_DIFF: Duration = if let Some(duration) = DIFF.checked_mul(10) {
 	duration
 } else {

--- a/tests/util/std.rs
+++ b/tests/util/std.rs
@@ -4,7 +4,7 @@ use std::thread;
 use web_time::Duration;
 
 /// Sleeps for the given [`Duration`].
-#[allow(unused)]
+#[allow(clippy::allow_attributes, dead_code, reason = "not used by all tests")]
 pub(crate) fn sleep(duration: Duration) -> Ready<()> {
 	thread::sleep(duration);
 	future::ready(())

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1,7 +1,8 @@
 //! Test Web-specific API exported in [`web_time::web`].
 
 #![cfg(test)]
-#![cfg(target_family = "wasm")]
+
+mod util;
 
 use std::time;
 use std::time::Duration;
@@ -9,8 +10,7 @@ use std::time::Duration;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::web::SystemTimeExt;
 
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
+/// Testing conversion from [`web_time`] to [`std`].
 #[wasm_bindgen_test]
 fn to_std() {
 	assert_eq!(
@@ -25,6 +25,7 @@ fn to_std() {
 	);
 }
 
+/// Testing conversion from [`std`] to [`web_time`].
 #[wasm_bindgen_test]
 fn from_std() {
 	assert_eq!(


### PR DESCRIPTION
- Through `no_std` support, we now also support `wasm32v1-none`.
- Introduced a new `std` crate feature that is enabled by default. Without it `#[no_std]` is enabled, but only on Web! This allows Web target to build without std, which is now supported by `wasm-bindgen` as well.

  Additionally, various changes had to be done to support `no_std`:
  - `no_std` does not support `thread_local!`, we use `once_cell` to polyfill this gap. `once_cell` is not a new dependency, it is already a dependency of `wasm-bindgen`.
    - With `feature = "std"`, we use `thread_local!` as before.
    - Without std and without `target_feature = "atomics"`, we use a `static mut` with `once_cell::unsync::Lazy`.
    - Without std and with atomics, we use [`#[thread_local]`](https://doc.rust-lang.org/1.83.0/unstable-book/language-features/thread-local.html?highlight=thread_l#thread_local) with `once_cell::unsync::Lazy`.
  - Some `f64` instructions are not available on `no_std` and had to be polyfilled. For this code from [`libm`](https://crates.io/crates/libm) was copied. Which is used by std as well.
  - `SystemTimeError` now only implements `Error` with `feature = "std"`.
  - `no_std` testing requires to refrain from using the default test harness. The problem was that native tests still needed to use the default test harness. To solve this, integration tests were removed from root crate and two workspace members added, that manually define all integration tests as test targets. The `tests-web` crate has `harness = false` on all tests, while `tests-native` functions regularly. This allow us to use the default test harness for native tests while disabling it for Web.

    Additionally, every test target requires the `run` crate feature, which are enabled by default depending on the target by the root crate. This way regular testing can function correctly for each target as long as `--all-features` is not used. E.g. `cargo test --workspace` and `cargo test --workspace --target wasm32-unknown-unknown` will work correctly.

    The `tests-web` library is used to implement the `panic_handler`, `global_allocator` and `critical_section`. It is always imported to reduce code duplication in all tests.
  - Used [`serde-json-core`](https://crates.io/crates/serde-json-core) to cover tests with `no_std` as well.
  - All links to std documentation had to be supplemented with manual link when `std` is not present.
- Improvements to CI:
  - Refactored all matrices for simplification and covering `--no-default-features`.
  - Split regular and minimal versions building off tests.
  - Split doctests from regular tests.
  - Update Rust toolchain when testing `cargo publish`.
  - Test coverage improvements:
    - The new `wasm-bindgen` update allows us to refrain from having to pass `cfg` flags to the `wasm-bindgen` proc-macros.
    - Use Rust `llvm-tools` instead of the official LLVM package.
    - Remove invalid `script` tag from coverage report.
    - Retain coverage artifact instead of limiting it to one day.
    - Refactor large environment variables into global level ones.
- Small fixes that were stumbled upon:
  - Expose `web_time::web` with `cfg(docsrs)` on native as well.
  - `Serialize` and `Deserialize` implementation are now marked with `doc(cfg(feature = "serde"))`.
  - Std docs.rs link unnecessarily including `stable`.
  - Recommendation for `-Ctarget-feature=+nontrapping-fptoint` was moved from the top-level to the "Usage" section.
  - The minimal version of Serde is now fully specified as v1.0.0.
  - Fix some typos in internal documentation.

`no_std` support for `serde_test`: https://github.com/serde-rs/test/pull/36
`no_std` support for `getrandom`: https://github.com/rust-random/getrandom/pull/541.
`no_std` Wasm `f64` instructions: https://github.com/rust-lang/stdarch/pull/1677