### PR TITLE
Test in different worker types and Node.js

### DIFF
--- a/.github/workflows/coverage-documentation.yaml
+++ b/.github/workflows/coverage-documentation.yaml
@@ -67,6 +67,7 @@ jobs:
         run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
       - name: Test
         env:
+          WASM_BINDGEN_USE_BROWSER: 1
           CHROMEDRIVER: chromedriver
         run: |
           mkdir coverage-output

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ env:
 jobs:
   test:
     name:
-      Test ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
-      matrix.features.description }}
+      Test ${{ matrix.driver.description }} ${{ matrix.environment.description }} ${{
+      matrix.rust.description }} ${{ matrix.features.description }}
 
-    runs-on: ${{ matrix.target.os }}
+    runs-on: ${{ matrix.driver.os }}
 
     timeout-minutes: 10
 
@@ -26,49 +26,84 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - {
-              os: ubuntu-latest,
-              target: wasm32-unknown-unknown,
-              description: Chrome,
-              name: CHROMEDRIVER,
-              value: chromedriver,
-            }
-          - {
-              os: ubuntu-latest,
-              target: wasm32-unknown-unknown,
-              description: Firefox,
-              name: GECKODRIVER,
-              value: geckodriver,
-            }
-          - {
-              os: macos-latest,
-              target: wasm32-unknown-unknown,
-              description: Safari,
-              name: SAFARIDRIVER,
-              value: safaridriver,
-            }
+          - { target: wasm32-unknown-unknown, docargs: -Zdoctest-xcompile }
         rust:
-          - { version: stable }
+          - { version: nightly }
           - {
               version: nightly,
               description: with Atomics,
               component: --component rust-src,
               flags: "-Ctarget-feature=+atomics,+bulk-memory",
               build-std: true,
+              atomics: true,
             }
         features:
           - { features: "", no_std: false }
           - { features: --no-default-features, no_std: true, description: "(`no_std`)" }
+        driver:
+          - {
+              os: ubuntu-latest,
+              description: Chrome,
+              name: CHROMEDRIVER,
+              value: chromedriver,
+              browser: true,
+            }
+          - {
+              os: ubuntu-latest,
+              description: Firefox,
+              name: GECKODRIVER,
+              value: geckodriver,
+              browser: true,
+              firefox: true,
+            }
+          - {
+              os: macos-latest,
+              description: Safari,
+              name: SAFARIDRIVER,
+              value: safaridriver,
+              browser: true,
+            }
+          - { os: ubuntu-24.04, description: Node.js, nodejs: true }
+        environment:
+          - { name: WASM_BINDGEN_USE_BROWSER, browser: true }
+          - {
+              description: Dedicated Worker,
+              name: WASM_BINDGEN_USE_DEDICATED_WORKER,
+              browser: true,
+            }
+          - {
+              description: Shared Worker,
+              name: WASM_BINDGEN_USE_SHARED_WORKER,
+              browser: true,
+              shared-worker: true,
+            }
+          - {
+              description: Service Worker,
+              name: WASM_BINDGEN_USE_SERVICE_WORKER,
+              browser: true,
+              service-worker: true,
+            }
+          - { browser: false }
         include:
-          - target:
-              {
-                os: ubuntu-latest,
-                target: x86_64-unknown-linux-gnu,
-                description: Native,
-                native: true,
-              }
+          - target: { target: x86_64-unknown-linux-gnu }
             rust: { version: stable }
             features: { features: "", no_std: false }
+            driver: { os: ubuntu-latest, description: Native, native: true }
+        exclude:
+          - driver: { browser: true }
+            environment: { browser: false }
+          - driver: { nodejs: true }
+            environment: { browser: true }
+          # Firefox doesn't support `Atomics.waitAsync()` and the polyfill requires spawning workers.
+          - driver: { firefox: true }
+            rust: { atomics: true }
+            environment: { shared-worker: true }
+          # Firefox doesn't support module service workers.
+          - driver: { firefox: true }
+            environment: { service-worker: true }
+          # `wasm-bindgen` support of Node.js with atomics is incomplete.
+          - driver: { nodejs: true }
+            rust: { atomics: true }
 
     steps:
       - name: Checkout
@@ -88,99 +123,15 @@ jobs:
         if: matrix.rust.build-std == true && matrix.features.no_std == true
         run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
       - name: Set Driver
-        if: matrix.target.native == false
-        run: echo "${{ matrix.target.name }}=${{ matrix.target.value }}" >> $GITHUB_ENV
+        if: matrix.driver.browser == true
+        run: echo "${{ matrix.driver.name }}=${{ matrix.driver.value }}" >> $GITHUB_ENV
+      - name: Set Environment
+        if: matrix.environment.browser == true
+        run: echo "${{ matrix.environment.name }}=1" >> $GITHUB_ENV
       - name: Test
-        env:
-          RUSTFLAGS: ${{ matrix.rust.flags }}
-        run:
-          cargo test --features serde ${{ matrix.features.features }} --target ${{
-          matrix.target.target }} $BUILD_STD_COMPONENTS --workspace
-
-  doctest:
-    name:
-      Doctest ${{ matrix.target.description }} ${{ matrix.rust.description }} ${{
-      matrix.features.description }}
-
-    runs-on: ${{ matrix.target.os }}
-
-    timeout-minutes: 10
-
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - {
-              os: ubuntu-latest,
-              target: wasm32-unknown-unknown,
-              description: Chrome,
-              name: CHROMEDRIVER,
-              value: chromedriver,
-            }
-          - {
-              os: ubuntu-latest,
-              target: wasm32-unknown-unknown,
-              description: Firefox,
-              name: GECKODRIVER,
-              value: geckodriver,
-            }
-          - {
-              os: macos-latest,
-              target: wasm32-unknown-unknown,
-              description: Safari,
-              name: SAFARIDRIVER,
-              value: safaridriver,
-            }
-        rust:
-          - { version: nightly }
-          - {
-              version: nightly,
-              description: with Atomics,
-              component: --component rust-src,
-              flags: "-Ctarget-feature=+atomics,+bulk-memory",
-              build-std: true,
-            }
-        features:
-          - { features: "", no_std: false }
-          - { features: --no-default-features, no_std: true, description: "(`no_std`)" }
-        include:
-          - target:
-              {
-                os: ubuntu-latest,
-                target: x86_64-unknown-linux-gnu,
-                description: Native,
-                native: true,
-              }
-            rust: { version: stable }
-            features: { features: "", no_std: false }
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install `wasm-bindgen-cli`
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-bindgen-cli
-      - name: Install Rust
-        run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile minimal ${{ matrix.rust.component }} --target ${{ matrix.target.target }}
-          rustup default ${{ matrix.rust.version }}
-      - name: Set `build-std` components
-        if: matrix.rust.build-std == true && matrix.features.no_std == false
-        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=panic_abort,std" >> $GITHUB_ENV
-      - name: Set `build-std` `no_std` components
-        if: matrix.rust.build-std == true && matrix.features.no_std == true
-        run: echo "BUILD_STD_COMPONENTS=-Zbuild-std=core,alloc" >> $GITHUB_ENV
-      - name: Set Driver and enable cross-compilation
-        if: matrix.target.native == false
-        run: |
-          echo "${{ matrix.target.name }}=${{ matrix.target.value }}" >> $GITHUB_ENV
-          echo "DOCTEST_XCOMPILE_ARG=-Zdoctest-xcompile" >> $GITHUB_ENV
-      - name: Doctest
         env:
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
         run:
           cargo test --features serde ${{ matrix.features.features }} --target ${{
-          matrix.target.target }} $BUILD_STD_COMPONENTS --workspace --doc ${{ matrix.target.args }}
-          $DOCTEST_XCOMPILE_ARG
+          matrix.target.target }} $BUILD_STD_COMPONENTS --workspace ${{ matrix.target.docargs }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,6 @@
 //! # #[cfg(target_arch = "wasm32")]
 //! # use tests_web as _;
 //! #
-//! # wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-//! #
 //! # #[wasm_bindgen_test::wasm_bindgen_test]
 //! # fn main() {
 //! let now = Instant::now();
@@ -189,9 +187,6 @@ pub use self::time::*;
 
 #[cfg(all(not(doc), docsrs))]
 compile_error!("`--cfg docsrs` must only be used via `RUSTDOCFLAGS`, not `RUSTFLAGS`");
-
-#[cfg(all(test, target_arch = "wasm32"))]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 fn main() {}

--- a/tests-web/Cargo.toml
+++ b/tests-web/Cargo.toml
@@ -53,9 +53,8 @@ web-time = { path = "../", default-features = false }
 futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = [
-	"DedicatedWorkerGlobalScope",
+	"console",
 	"OfflineAudioContext",
-	"WorkerGlobalScope",
 ] }
 web-thread = { git = "https://github.com/daxpedda/wasm-worker", rev = "93236ab92354cbe0a0c07e71b9888be8b3e45999", optional = true, features = [
 	"audio-worklet",

--- a/tests/atomic_failure.rs
+++ b/tests/atomic_failure.rs
@@ -8,7 +8,7 @@ mod util;
 use futures_util::future;
 use futures_util::future::Either;
 use wasm_bindgen_test::wasm_bindgen_test;
-use web_sys::OfflineAudioContext;
+use web_sys::{console, OfflineAudioContext};
 use web_thread::web::audio_worklet::BaseAudioContextExt;
 use web_time::Instant;
 
@@ -17,6 +17,11 @@ use self::util::{Flag, MAX_DIFF};
 /// Testing failure of [`Instant::now()`] in audio worklet.
 #[wasm_bindgen_test]
 async fn test() {
+	if web_sys::window().is_none() {
+		console::error_1(&"found ourselves not in a `Window`".into());
+		return;
+	}
+
 	let context =
 		OfflineAudioContext::new_with_number_of_channels_and_length_and_sample_rate(1, 1, 8000.)
 			.unwrap();

--- a/tests/atomic_success.rs
+++ b/tests/atomic_success.rs
@@ -7,13 +7,19 @@ mod util;
 
 use futures_channel::oneshot;
 use wasm_bindgen_test::wasm_bindgen_test;
-use web_thread::web;
+use web_sys::console;
+use web_thread::web::{self, has_spawn_support};
 use web_time::{Duration, Instant};
 
-use self::util::{sleep, Flag, DIFF};
+use self::util::{sleep, Flag, DIFF, WAIT};
 
 #[wasm_bindgen_test]
 async fn basic() {
+	if !has_spawn_support() {
+		console::error_1(&"can't spawn threads".into());
+		return;
+	}
+
 	let earlier = Instant::now();
 
 	let flag = Flag::new();
@@ -24,7 +30,7 @@ async fn basic() {
 			let later = Instant::now();
 			assert!(earlier <= later, "{:?}", earlier - later);
 
-			sleep(DIFF).await;
+			sleep(WAIT).await;
 
 			let later = Instant::now();
 			assert!((later - earlier) >= DIFF, "{:?}", later - earlier);
@@ -41,6 +47,11 @@ async fn basic() {
 
 #[wasm_bindgen_test]
 async fn delay() {
+	if !has_spawn_support() {
+		console::error_1(&"can't spawn threads".into());
+		return;
+	}
+
 	sleep(Duration::from_secs(2)).await;
 
 	let earlier = Instant::now();
@@ -53,7 +64,7 @@ async fn delay() {
 			let later = Instant::now();
 			assert!(earlier <= later, "{:?}", earlier - later);
 
-			sleep(DIFF).await;
+			sleep(WAIT).await;
 
 			let later = Instant::now();
 			assert!((later - earlier) >= DIFF, "{:?}", later - earlier);
@@ -70,6 +81,11 @@ async fn delay() {
 
 #[wasm_bindgen_test]
 async fn worker() {
+	if !has_spawn_support() {
+		console::error_1(&"can't spawn threads".into());
+		return;
+	}
+
 	let (sender, receiver) = oneshot::channel();
 	web::spawn_async(move || async move { sender.send(Instant::now()).unwrap() });
 
@@ -77,7 +93,7 @@ async fn worker() {
 	let later = Instant::now();
 	assert!(earlier <= later, "{:?}", earlier - later);
 
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 
 	let later = Instant::now();
 	assert!((later - earlier) >= DIFF, "{:?}", later - earlier);

--- a/tests/instant_failure_1.rs
+++ b/tests/instant_failure_1.rs
@@ -10,13 +10,13 @@ mod util;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
-use self::util::{sleep, DIFF};
+use self::util::{sleep, WAIT};
 
 /// [`Instant::add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 #[should_panic = "overflow when adding duration to instant"]
 async fn add_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let _ = Instant::now() + Duration::MAX;
 }
 

--- a/tests/instant_failure_2.rs
+++ b/tests/instant_failure_2.rs
@@ -10,13 +10,13 @@ mod util;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
-use self::util::{sleep, DIFF};
+use self::util::{sleep, WAIT};
 
 /// [`Instant::add_assign()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 #[should_panic = "overflow when adding duration to instant"]
 async fn add_assign_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let mut instant = Instant::now();
 	instant += Duration::MAX;
 }

--- a/tests/instant_success.rs
+++ b/tests/instant_success.rs
@@ -9,15 +9,15 @@ mod util;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, Instant};
 
-use self::util::{sleep, DIFF, MAX_DIFF};
+use self::util::{sleep, DIFF, MAX_DIFF, WAIT};
 
 /// [`Instant::duration_since()`] success.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn duration_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = Instant::now().duration_since(instant);
-	assert!(duration >= DIFF);
+	assert!(duration >= DIFF, "{duration:?}");
 	assert!(duration <= MAX_DIFF);
 }
 
@@ -25,7 +25,7 @@ async fn duration_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn duration_failure() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert_eq!(instant.duration_since(Instant::now()), Duration::ZERO);
 }
 
@@ -33,9 +33,9 @@ async fn duration_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_duration_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = Instant::now().checked_duration_since(instant);
-	assert!(duration >= Some(DIFF));
+	assert!(duration >= Some(DIFF), "{duration:?}");
 	assert!(duration <= Some(MAX_DIFF));
 }
 
@@ -43,7 +43,7 @@ async fn checked_duration_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_duration_failure() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert_eq!(instant.checked_duration_since(Instant::now()), None);
 }
 
@@ -51,9 +51,9 @@ async fn checked_duration_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn saturating_duration_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = Instant::now().saturating_duration_since(instant);
-	assert!(duration >= DIFF);
+	assert!(duration >= DIFF, "{duration:?}");
 	assert!(duration <= MAX_DIFF);
 }
 
@@ -61,7 +61,7 @@ async fn saturating_duration_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn saturating_duration_failure() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert_eq!(
 		instant.saturating_duration_since(Instant::now()),
 		Duration::ZERO
@@ -72,9 +72,9 @@ async fn saturating_duration_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn elapsed() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = instant.elapsed();
-	assert!(duration >= DIFF);
+	assert!(duration >= DIFF, "{duration:?}");
 	assert!(duration <= MAX_DIFF);
 }
 
@@ -82,16 +82,20 @@ async fn elapsed() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_add_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = Instant::now();
-	assert!(instant.checked_add(DIFF).unwrap() <= now);
+	assert!(
+		instant.checked_add(DIFF).unwrap() <= now,
+		"{:?}",
+		now - instant
+	);
 	assert!(instant.checked_add(MAX_DIFF).unwrap() >= now);
 }
 
 /// [`Instant::checked_add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_add_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert_eq!(Instant::now().checked_add(Duration::MAX), None);
 }
 
@@ -99,9 +103,13 @@ async fn checked_add_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_sub_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = Instant::now();
-	assert!(now.checked_sub(DIFF).unwrap() >= instant);
+	assert!(
+		now.checked_sub(DIFF).unwrap() >= instant,
+		"{:?}",
+		now - instant
+	);
 	assert!(now.duration_since(instant) <= MAX_DIFF);
 }
 
@@ -115,9 +123,9 @@ fn checked_sub_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn add_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = Instant::now();
-	assert!(instant + DIFF <= now);
+	assert!(instant + DIFF <= now, "{:?}", now - instant);
 	assert!(instant + MAX_DIFF >= now);
 }
 
@@ -125,10 +133,10 @@ async fn add_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn add_assign_success() {
 	let mut instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = Instant::now();
 	instant += DIFF;
-	assert!(instant <= now);
+	assert!(instant <= now, "{:?}", now - instant);
 	instant += DIFF;
 	assert!(instant >= now);
 }
@@ -142,9 +150,9 @@ async fn add_assign_success() {
 )]
 async fn sub_success() {
 	let instant = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = Instant::now();
-	assert!(now - DIFF >= instant);
+	assert!(now - DIFF >= instant, "{:?}", now - instant);
 	assert!(now.duration_since(instant) <= MAX_DIFF);
 }
 
@@ -152,7 +160,7 @@ async fn sub_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn sub_assign_success() {
 	let earlier = Instant::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let mut later = Instant::now();
 	later -= DIFF;
 	assert!(later >= earlier);
@@ -167,7 +175,7 @@ async fn comparison() {
 	let later = Instant::now();
 	assert!(earlier <= later, "{:?}", earlier - later);
 
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 
 	let later = Instant::now();
 	assert!((later - earlier) >= DIFF, "{:?}", later - earlier);

--- a/tests/system_time_failure_1.rs
+++ b/tests/system_time_failure_1.rs
@@ -10,13 +10,13 @@ mod util;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
-use self::util::{sleep, DIFF};
+use self::util::{sleep, WAIT};
 
 /// [`SystemTime::add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 #[should_panic = "overflow when adding duration to instant"]
 async fn add_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let _ = SystemTime::now() + Duration::MAX;
 }
 

--- a/tests/system_time_failure_2.rs
+++ b/tests/system_time_failure_2.rs
@@ -10,13 +10,13 @@ mod util;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
-use self::util::{sleep, DIFF};
+use self::util::{sleep, WAIT};
 
 /// [`SystemTime::add_assign()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 #[should_panic = "overflow when adding duration to instant"]
 async fn add_assign_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let mut time = SystemTime::now();
 	time += Duration::MAX;
 }

--- a/tests/system_time_success.rs
+++ b/tests/system_time_success.rs
@@ -13,7 +13,7 @@ use alloc::string::ToString;
 use wasm_bindgen_test::wasm_bindgen_test;
 use web_time::{Duration, SystemTime};
 
-use self::util::{sleep, DIFF, MAX_DIFF};
+use self::util::{sleep, DIFF, MAX_DIFF, WAIT};
 
 /// [`SystemTime::UNIX_EPOCH`].
 #[allow(
@@ -31,7 +31,7 @@ fn unix_epoch() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn duration_since_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = SystemTime::now().duration_since(time).unwrap();
 	assert!(duration >= DIFF);
 	assert!(duration <= MAX_DIFF);
@@ -41,7 +41,7 @@ async fn duration_since_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn duration_since_failure() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let error = time.duration_since(SystemTime::now()).unwrap_err();
 	let duration = error.duration();
 	assert!(duration >= DIFF);
@@ -52,7 +52,7 @@ async fn duration_since_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn elapsed_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let duration = time.elapsed().unwrap();
 	assert!(duration >= DIFF);
 	assert!(duration <= MAX_DIFF);
@@ -61,16 +61,16 @@ async fn elapsed_success() {
 /// [`SystemTime::elapsed()`] failure.
 #[wasm_bindgen_test(unsupported = test)]
 fn elapsed_failure() {
-	let time = SystemTime::now() + DIFF;
+	let time = SystemTime::now() + WAIT;
 	let error = time.elapsed().unwrap_err();
-	assert!(error.duration() <= DIFF);
+	assert!(error.duration() <= WAIT);
 }
 
 /// [`SystemTime::checked_add()`] success.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_add_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = SystemTime::now();
 	assert!(time.checked_add(DIFF).unwrap() <= now);
 	assert!(time.checked_add(MAX_DIFF).unwrap() >= now);
@@ -79,7 +79,7 @@ async fn checked_add_success() {
 /// [`SystemTime::checked_add()`] failure.
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_add_failure() {
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert_eq!(SystemTime::now().checked_add(Duration::MAX), None);
 }
 
@@ -87,7 +87,7 @@ async fn checked_add_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn checked_sub_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = SystemTime::now();
 	assert!(now.checked_sub(DIFF).unwrap() >= time);
 	assert!(now.checked_sub(MAX_DIFF).unwrap_or(SystemTime::UNIX_EPOCH) <= time);
@@ -103,7 +103,7 @@ fn checked_sub_failure() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn add_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	assert!(time + DIFF <= SystemTime::now());
 	assert!(time + MAX_DIFF >= SystemTime::now());
 }
@@ -113,7 +113,7 @@ async fn add_success() {
 async fn add_assign_success() {
 	let mut time_1 = SystemTime::now();
 	let mut time_2 = time_1;
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = SystemTime::now();
 	time_1 += DIFF;
 	assert!(time_1 <= now);
@@ -125,7 +125,7 @@ async fn add_assign_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn sub_success() {
 	let time = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let now = SystemTime::now();
 	assert!(now - DIFF >= time);
 	assert!(now.duration_since(time).unwrap() <= MAX_DIFF);
@@ -135,7 +135,7 @@ async fn sub_success() {
 #[wasm_bindgen_test(unsupported = pollster::test)]
 async fn sub_assign_success() {
 	let earlier = SystemTime::now();
-	sleep(DIFF).await;
+	sleep(WAIT).await;
 	let mut later = SystemTime::now();
 	later -= DIFF;
 	assert!(later >= earlier);

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -24,13 +24,14 @@ pub(crate) use self::std::*;
 )]
 pub(crate) use self::web::*;
 
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
+/// Time to wait.
+pub(crate) const WAIT: Duration = Duration::from_millis(50);
 /// Difference to measure that time has passed.
-pub(crate) const DIFF: Duration = Duration::from_millis(50);
+#[allow(clippy::allow_attributes, dead_code, reason = "not used by all tests")]
+pub(crate) const DIFF: Duration = Duration::from_millis(49);
 /// Maximum difference that can't have been passed by [`DIFF`].
 #[allow(clippy::allow_attributes, dead_code, reason = "not used by all tests")]
-pub(crate) const MAX_DIFF: Duration = if let Some(duration) = DIFF.checked_mul(10) {
+pub(crate) const MAX_DIFF: Duration = if let Some(duration) = WAIT.checked_mul(10) {
 	duration
 } else {
 	panic!()

--- a/tests/util/web.rs
+++ b/tests/util/web.rs
@@ -14,14 +14,9 @@ use core::time::Duration;
 
 #[cfg(all(target_feature = "atomics", feature = "std"))]
 use futures_util::task::AtomicWaker;
-use js_sys::Promise;
-#[cfg(all(target_feature = "atomics", feature = "std"))]
+use js_sys::{Function, Promise};
 use wasm_bindgen::prelude::wasm_bindgen;
-#[cfg(all(target_feature = "atomics", feature = "std"))]
-use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
-#[cfg(all(target_feature = "atomics", feature = "std"))]
-use web_sys::{DedicatedWorkerGlobalScope, Window};
 
 /// Async version of [`std::thread::sleep()`].
 pub(crate) struct Sleep(JsFuture);
@@ -38,62 +33,16 @@ impl Future for Sleep {
 /// Sleeps for the given [`Duration`].
 #[allow(clippy::allow_attributes, dead_code, reason = "not used by all tests")]
 pub(crate) fn sleep(duration: Duration) -> Sleep {
-	/// Holding the [global object](https://developer.mozilla.org/en-US/docs/Glossary/Global_object).
-	#[cfg(all(target_feature = "atomics", feature = "std"))]
-	enum Global {
-		/// The window.
-		Window(Window),
-		/// A dedicated worker.
-		DedicatedWorker(DedicatedWorkerGlobalScope),
+	#[wasm_bindgen]
+	extern "C" {
+		#[wasm_bindgen(js_name = setTimeout)]
+		fn set_timeout(handler: &Function, timeout: i32);
 	}
 
-	#[cfg(all(target_feature = "atomics", feature = "std"))]
-	thread_local! {
-		/// Cached [`Global`].
-		static GLOBAL: Global = {
-			#[wasm_bindgen]
-			extern "C" {
-				type SleepGlobal;
-
-				#[wasm_bindgen(method, getter, js_name = Window)]
-				fn window(this: &SleepGlobal) -> JsValue;
-
-				#[wasm_bindgen(method, getter, js_name = DedicatedWorkerGlobalScope)]
-				fn worker(this: &SleepGlobal) -> JsValue;
-			}
-
-			let global: SleepGlobal = js_sys::global().unchecked_into();
-
-			if !global.window().is_undefined() {
-				Global::Window(global.unchecked_into())
-			} else if !global.worker().is_undefined() {
-				Global::DedicatedWorker(global.unchecked_into())
-			} else {
-				unreachable!("only supported in a browser or web worker")
-			}
-		};
-	}
-
-	let future =
-		JsFuture::from(Promise::new(&mut |resolve, _| {
-			let duration = duration.as_millis().try_into().unwrap();
-
-			#[cfg(not(all(target_feature = "atomics", feature = "std")))]
-			web_sys::window()
-				.unwrap()
-				.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, duration)
-				.unwrap();
-
-			#[cfg(all(target_feature = "atomics", feature = "std"))]
-			GLOBAL
-				.with(|global| match global {
-					Global::Window(window) => window
-						.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, duration),
-					Global::DedicatedWorker(worker) => worker
-						.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, duration),
-				})
-				.unwrap();
-		}));
+	let future = JsFuture::from(Promise::new(&mut |resolve, _| {
+		let duration = duration.as_millis().try_into().unwrap();
+		set_timeout(&resolve, duration);
+	}));
 
 	Sleep(future)
 }


### PR DESCRIPTION
This adds testing in browsers, dedicated workers, shared workers, service workers and Node.js to the test matrix.
To simplify things and probably speed up the CI Doctests were merged into the same job.